### PR TITLE
참여 정보 조회 Redis 캐싱 적용

### DIFF
--- a/.claude/plans/redis-participation-cache.md
+++ b/.claude/plans/redis-participation-cache.md
@@ -1,0 +1,172 @@
+# Redis Participation Cache 계획
+
+## 목적
+
+`sendMessage`에서 `chatValidationService.requireParticipation(userId, chatId)` 호출 시 매번
+`SELECT ... FROM participation WHERE user_id = ? AND chat_id = ?` DB 쿼리가 발생한다.
+메시지 전송은 같은 사용자가 동일 채팅에서 반복 호출하는 가장 빈번한 연산이므로,
+Participation 조회 결과를 Redis에 캐시해 DB 부하를 줄인다.
+
+---
+
+## 1. 캐시 키
+
+```
+participation::{userId}:{chatId}
+```
+
+Spring Cache SpEL: `@Cacheable(cacheNames = "participation", key = "#userId + ':' + #chatId")`
+
+예시: `participation::user-uuid-123:chat-uuid-456`
+
+`userId + chatId` 조합이 Participation을 유일하게 특정하는 자연키이므로 별도 해시 불필요.
+
+---
+
+## 2. TTL
+
+**30분 (1800초)**
+
+- Participation은 삭제·변경 이벤트가 거의 없다(현재 코드에 leave·kick 없음).
+- 30분: 라이브 세션 재접속·역할 변경 등 예외 상황에서 stale 상태가 지속되는 최대 허용 시간.
+- 너무 길면(>1h) 역할 변경 시 stale data 위험; 너무 짧으면(<5m) cache miss 비율이 높아 효과 감소.
+
+---
+
+## 3. 변경 지점과 변경 이유
+
+### 3-1. `app/build.gradle` — 의존성 추가
+
+```groovy
+implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+```
+
+**이유**: Lettuce(기본 Redis 클라이언트) + `spring-cache` Redis 통합 제공. Sentinel 연결도 자동 지원.
+
+---
+
+### 3-2. `app/src/main/resources/application.yml` — Redis 연결 설정
+
+```yaml
+spring:
+  data:
+    redis:
+      sentinel:
+        master: mymaster
+        nodes:
+          - localhost:26379
+          - localhost:26380
+          - localhost:26381
+```
+
+**이유**: `infra/docker-compose.yml`에 이미 Sentinel 3노드(26379~26381)가 구성되어 있으므로
+단순 단일 노드 대신 Sentinel 연결을 사용한다.
+
+---
+
+### 3-3. `config/CacheConfig.java` (신규) — CacheManager 설정
+
+```java
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory factory) {
+        ObjectMapper mapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder().allowIfBaseType(Object.class).build(),
+                ObjectMapper.DefaultTyping.NON_FINAL
+            );
+
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(30))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new GenericJackson2JsonRedisSerializer(mapper)
+                )
+            );
+
+        return RedisCacheManager.builder(factory)
+            .cacheDefaults(config)
+            .build();
+    }
+}
+```
+
+**이유**: 기본 `ConcurrentMapCacheManager`는 JVM 메모리 내에만 저장되며 TTL이 없다.
+`RedisCacheManager`로 교체해야 Redis에 저장되고 TTL이 적용된다.
+`GenericJackson2JsonRedisSerializer`는 타입 정보를 JSON에 포함하므로 역직렬화 시 명시적 타입 지정이 불필요.
+
+---
+
+### 3-4. `entity/Participation.java` — `@JsonCreator` 역직렬화 팩토리 추가
+
+```java
+@JsonCreator
+static Participation jsonDeserialize(
+    @JsonProperty("id") String id,
+    @JsonProperty("userId") String userId,
+    @JsonProperty("chatId") String chatId,
+    @JsonProperty("role") ParticipationRole role,
+    @JsonProperty("createdAt") LocalDateTime createdAt) {
+    Participation p = new Participation();  // protected 기본 생성자
+    p.id = id;
+    p.userId = userId;
+    p.chatId = chatId;
+    p.role = role;
+    p.createdAt = createdAt;
+    return p;
+}
+```
+
+**이유**: `Participation`의 생성자는 `private`이고 `@NoArgsConstructor(access = PROTECTED)`라
+Jackson이 기본 설정으로는 인스턴스를 생성할 수 없다.
+
+`ObjectMapper.setVisibility(FIELD, ANY)`로 우회할 수도 있지만, 이는 해당 ObjectMapper로
+캐시되는 **모든 타입**에 영향을 미치는 전역 설정이다. `@JsonCreator`를 명시하면 `Participation`이
+자신의 역직렬화 방법을 직접 선언하므로, 범위가 타입 단위로 한정되고 의도가 코드에 드러난다.
+
+같은 클래스 내의 메서드이므로 `protected` 기본 생성자와 `private` 필드에 직접 접근할 수 있다.
+직렬화(Java → JSON)는 `@Getter`가 생성하는 public getter로 이미 동작한다.
+
+---
+
+### 3-5. `ChatValidationService.requireParticipation()` — `@Cacheable` 추가
+
+```java
+@Cacheable(cacheNames = "participation", key = "#userId + ':' + #chatId")
+public Participation requireParticipation(String userId, String chatId) {
+    return participationRepository.findByUserIdAndChatId(userId, chatId)
+        .orElseThrow(() -> new NotParticipatingException("참여 중인 채팅이 아닙니다."));
+}
+```
+
+**이유**: 이 메서드는 `sendMessage`, `getMessageList`, `blockUser`, `unblockUser` 모두에서 호출된다.
+`sendMessage`만 아니라 전체에 캐시 효과가 적용되며, 로직 중복 없이 한 곳에서 관리할 수 있다.
+
+---
+
+## 4. 실행 단계
+
+| 순서 | 작업 | 파일 |
+|---|---|---|
+| 1 | `spring-boot-starter-data-redis` 의존성 추가 | `app/build.gradle` |
+| 2 | Redis Sentinel 연결 설정 추가 | `app/src/main/resources/application.yml` |
+| 3 | `CacheConfig.java` 생성: `@EnableCaching`, `RedisCacheManager`, TTL 30분 | `app/src/main/java/.../config/CacheConfig.java` |
+| 4 | `Participation`에 `@JsonCreator` 역직렬화 팩토리 추가 | `entity/Participation.java` |
+| 5 | `ChatValidationService.requireParticipation()`에 `@Cacheable` 추가 | `ChatValidationService.java` |
+| 6 | 테스트: `sendMessage` 두 번 연속 호출 시 `participationRepository.findByUserIdAndChatId`가 1회만 실행되는지 `verify(repo, times(1))` 검증 | `ChatServiceIntegrationTest.java` |
+| 7 | Redis 없는 환경(로컬 단위 테스트)에서 캐시가 비활성화되는지 확인 (`@ActiveProfiles("test")` + `@TestPropertySource`로 `cache.type=none` 설정) | 테스트 설정 |
+
+---
+
+## 주의사항
+
+- `requireParticipation()`은 `@Transactional` 메서드 내부에서도 호출된다(`blockUser`, `unblockUser`).
+  Spring Cache는 트랜잭션과 독립적으로 동작하므로, 트랜잭션 롤백이 발생해도 캐시는 evict되지 않는다.
+  현재 코드에서 `requireParticipation()`은 읽기 전용 조회이므로 롤백 시 캐시 불일치가 생길 여지는 없다.
+- `Participation`의 `createdAt`은 생성자에서 `LocalDateTime.now()`로 설정되며,
+  캐시 복원 시 이 값이 그대로 재사용된다. 시간 기반 로직에 `createdAt`을 쓰지 않으므로 문제없다.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew test *)",
+      "Bash(xargs grep *)"
+    ]
+  },
+  "prefersReducedMotion": false
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,11 @@
   "permissions": {
     "allow": [
       "Bash(./gradlew test *)",
-      "Bash(xargs grep *)"
+      "Bash(xargs grep *)",
+      "Bash(Get-ChildItem -Path \"D:\\\\MyThings\\\\Study\\\\PersonalStudy\\\\WebProgramming\\\\f-lab\\\\live-commerce\" -Recurse -Filter \"*.java\")",
+      "Bash(Select-Object -ExpandProperty FullName)",
+      "Bash(Sort-Object)",
+      "Bash(./gradlew.bat test *)"
     ]
   },
   "prefersReducedMotion": false

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,6 +3,7 @@ name: Run Tests with Testcontainers
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 # Ignore env file
 .env
+
+# Claude files
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Ignore env file
 .env
+*.env
 
 # Claude files
 .claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Run
+
+```bash
+# Build
+./gradlew.bat build
+
+# Run all tests
+./gradlew.bat test
+
+# Run a single test class
+./gradlew.bat test --tests "io.github.jaehyeonhan.project.service.ChatServiceTest"
+
+# Start with Docker Compose (requires .env in project root)
+docker compose up
+
+# Local run (requires DB env vars set)
+./gradlew.bat bootRun
+```
+
+**Environment variables** (set in `.env` or shell):
+| Variable | Default | Notes |
+|---|---|---|
+| `DB_URL` | — | e.g. `jdbc:postgresql://postgres:5432/chat` |
+| `DB_USER` | `user` | |
+| `DB_PASSWORD` | `pass` | |
+| `DB_NAME` | `chat` | |
+| `SQL_INIT_MODE` | `never` | Use `always` to re-run `schema.sql` on startup |
+
+## Architecture
+
+Single Gradle module (`app`) with a classic layered architecture:
+
+```
+Controller → Service → Repository (interface) → JPA impl → PostgreSQL
+```
+
+**Package layout** (`io.github.jaehyeonhan.project`):
+- `controller/` — REST endpoints, request/response DTOs under `dto/request` and `dto/response`
+- `service/` — business logic (`ChatService`) and validation (`ChatValidationService`)
+- `repository/` — repository interfaces; JPA implementations live in `repository/jpa/`
+- `entity/` — JPA entities (`Chat`, `Message`, `Participation`, `Block`, `ParticipationRole`)
+- `exception/` — domain exceptions + `ChatControllerAdvice` (global `@RestControllerAdvice`)
+- `config/` — `ClockConfig` (injects a `Clock` bean for testable time)
+- `constant/` — `TimeConstant` (block duration bounds)
+
+**Domain rules:**
+- Participation roles: `CREATOR > MANAGER > USER`
+- CREATOR/MANAGER can block users for 5–30 minutes or permanently (duration `0` = infinite); only the blocker can retract a block
+- Message polling uses a `lastRead` cursor (return messages newer than that ID)
+
+**Infrastructure** (`infra/`): Redis Sentinel (1 master + 2 replicas) with OpenResty for reverse-proxy and Lua-based token-bucket rate limiting. This infra is separate from the main app's `docker-compose.yml`.
+
+## Testing
+
+- **Unit tests** mock `ChatValidationService` and repositories via Mockito
+- **Integration tests** (`ChatServiceIntegrationTest`) spin up a real PostgreSQL container via Testcontainers — no mocking of the DB layer
+- CI runs tests on PR via GitHub Actions (`.github/workflows/run-tests.,yml`)
+- SonarCloud static analysis runs on PR (`.github/workflows/sonarcloud-analyze.yml`)
+- method name should follow "given_condition_when_execution_then_verification" pattern
+
+## Database
+
+Schema is managed manually in `app/src/main/resources/schema.sql` (Hibernate DDL is set to `none`). Tables: `chat`, `participation`, `message`, `block`.
+
+Swagger UI is available at `/swagger-ui.html` when the app is running (SpringDoc OpenAPI).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,6 +9,8 @@ repositories {
     mavenCentral()
 }
 
+ext['testcontainers.version'] = '2.0.5'
+
 dependencies {
 
     // PostgreSQL
@@ -16,6 +18,13 @@ dependencies {
 
     // Spring Data JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Resilience4j
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.3.0'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
@@ -25,8 +34,8 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 
     // Testcontainers
-    testImplementation 'org.testcontainers:testcontainers-postgresql:2.0.1'
-    testImplementation "org.testcontainers:testcontainers-junit-jupiter:2.0.1"
+    testImplementation 'org.testcontainers:testcontainers-postgresql:2.0.5'
+    testImplementation "org.testcontainers:testcontainers-junit-jupiter:2.0.5"
     testImplementation 'commons-io:commons-io:2.21.0'
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,6 +26,10 @@ dependencies {
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.3.0'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
 
+    // Actuator & Metrics
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/app/docs/decisions/0007-use-participation-cache-for-message-send-API.md
+++ b/app/docs/decisions/0007-use-participation-cache-for-message-send-API.md
@@ -1,0 +1,33 @@
+# Participation Lookup Caching for Message Send API
+
+## Context and Problem Statement
+
+The message sending API performs a `(userId, chatId) → participationId` lookup on every request. Under increased traffic, this results in a linear increase in database read load.
+
+In addition, message sending requires a block validation check to ensure that blocked users cannot send messages. This introduces an additional database read on the hot path, further increasing read pressure.
+
+This raises concerns about scalability of the DB read path under high traffic.
+
+## Considered Options
+
+- Keep DB-only architecture (no caching)
+- Denormalize participation data (include block status in participation)
+- Apply Redis-based cache-aside pattern for participation lookup
+
+## Decision Outcome
+
+**Chosen option**: Redis-based cache-aside pattern for participation lookup
+
+**Reasons**
+
+- DB-only architecture results in linear growth of read load as traffic increases.
+- Denormalization approach was rejected due to consistency requirements. Block status must be reflected immediately, and relying on cache invalidation introduces risk of stale state due to potential invalidation failure. Additionally, reducing TTL to mitigate staleness significantly reduces cache effectiveness under expected traffic patterns. Block validation is intentionally excluded for the same reason.
+- Redis cache-aside approach reduces DB load by caching `(userId, chatId) → participationId` mappings and leverages locality in chat usage patterns. Given the nature of chat systems, repeated message sending within the same chat context is expected.
+
+### Considerations
+
+- Participation cache is applied only to lookup path and must not be used for authorization decisions.
+- Block validation remains fully DB-driven to ensure correctness and avoid stale state issues.
+- Cache invalidation strategy is optional and TTL-based caching is acceptable as there is no leave operation, and the mutation frequency of participation mappings is expected to be low in the future as well.
+- System still requires DB as the source of truth for all authorization-related logic.
+- Cache effectiveness depends on actual traffic locality characteristics and may vary under different usage patterns.

--- a/app/docs/decisions/0008-add-resilience-for-redis.md
+++ b/app/docs/decisions/0008-add-resilience-for-redis.md
@@ -1,0 +1,29 @@
+# Add Bulkhead, Circuit Breaker, and Retry for Redis Cache
+
+## Context and Problem Statement
+
+The project utilizes Redis to reduce the usage of Database connections in send message API. Even though Redis is highly available through Sentinels, timeouts may occur during Sentinel fail-over resulting in significant queuing in the API, eventually leading to considerably increased latency.
+
+## Major Design Decisions
+
+Three resilience features are implemented.
+
+1. Circuit Breaker: Use DB fallback when Redis cache is not available or under significant degradation.
+2. Retry: Absorb transient delays or errors with Redis operations.
+3. Bulkhead: When circuit breaker opens, prevent database connection exhaustion, as well as in normal times.
+
+The actual call order is: Bulkhead → Circuit Breaker → Retry → Redis.
+When the circuit breaker is OPEN, the request immediately falls back to the database without executing retries.
+
+### Consequences
+
+* Good, because Redis fail-over no longer causes excessive API queuing and severe cascading latency under transient failures.
+* Good, because requests can continue through database fallback even when Redis becomes unavailable or significantly degraded.
+* Good, because transient Redis failures can be absorbed through retries, improving short-term request success rates.
+* Bad, because retry attempts may increase overall request latency before fallback or failure occurs.
+* Bad, because Bulkhead limits may reduce throughput even during normal Redis operation.
+* Bad, because the interaction between Bulkhead, Circuit Breaker, Retry, and timeout configurations increases operational and tuning complexity.
+
+### Considerations
+* Server could return 429 Too Many Request response when the server exceeds Bulkhead limits. It might be considered in the 
+* Since the resilience configurations were not validated against production-scale traffic, optimal values for Circuit Breaker thresholds, Retry counts, and timeout durations could not be fully determined.

--- a/app/src/main/java/io/github/jaehyeonhan/project/config/CacheConfig.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/config/CacheConfig.java
@@ -1,0 +1,31 @@
+package io.github.jaehyeonhan.project.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.github.jaehyeonhan.project.entity.ParticipationCache;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public RedisTemplate<String, ParticipationCache> participationRedisTemplate(
+            RedisConnectionFactory factory) {
+        ObjectMapper mapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        RedisTemplate<String, ParticipationCache> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(
+            new Jackson2JsonRedisSerializer<>(mapper, ParticipationCache.class));
+        return template;
+    }
+}

--- a/app/src/main/java/io/github/jaehyeonhan/project/constant/TimeConstant.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/constant/TimeConstant.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 public class TimeConstant {
 
-    public static LocalDateTime MAX_DATETIME = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+    private TimeConstant() {}
+    public static final LocalDateTime MAX_DATETIME = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
 
 }

--- a/app/src/main/java/io/github/jaehyeonhan/project/controller/dto/request/GetNewMessageRequest.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/controller/dto/request/GetNewMessageRequest.java
@@ -1,5 +1,6 @@
 package io.github.jaehyeonhan.project.controller.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -8,5 +9,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public class GetNewMessageRequest {
     private final String userId;
+
+    @Schema(example = "2025-11-22T02:53:40.578")
     private final LocalDateTime lastRead;
 }

--- a/app/src/main/java/io/github/jaehyeonhan/project/entity/Block.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/entity/Block.java
@@ -43,7 +43,7 @@ public class Block {
         LocalDateTime expiresAt,
         boolean retracted) {
         this.id = requireNonNull(id, "Block id");
-        this.participationId = requireNonNull(participationId, "Participation id");;
+        this.participationId = requireNonNull(participationId, "Participation id");
         this.createdAt = requireNonNull(createdAt, "Created at");
         this.expiresAt = requireNonNull(expiresAt, "Expires at");
         this.retracted = retracted;
@@ -52,7 +52,7 @@ public class Block {
     private static void validateDuration(int durationInMin) {
         if ((durationInMin < 5 && durationInMin != 0) || durationInMin > 30) {
             throw new InvalidBlockDurationException(
-                "block duartion should be between 5 and 30 minutes");
+                "block duration should be between 5 and 30 minutes");
         }
     }
 

--- a/app/src/main/java/io/github/jaehyeonhan/project/entity/Message.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/entity/Message.java
@@ -36,6 +36,9 @@ public class Message {
     }
 
     private void validateContent(String content) {
+        if (content.isBlank()) {
+            throw new InvalidMessageContentException("Message cannot be blank");
+        }
         if (content.length() > 300) {
             throw new InvalidMessageContentException("Message cannot be longer than 300 characters");
         }

--- a/app/src/main/java/io/github/jaehyeonhan/project/entity/Participation.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/entity/Participation.java
@@ -62,4 +62,15 @@ public class Participation {
     private boolean canPromoteToManager() {
         return this.role.equals(ParticipationRole.CREATOR);
     }
+
+    static Participation restoreFromCache(String id, String userId, String chatId,
+        ParticipationRole role, LocalDateTime createdAt) {
+        Participation p = new Participation();
+        p.id = id;
+        p.userId = userId;
+        p.chatId = chatId;
+        p.role = role;
+        p.createdAt = createdAt;
+        return p;
+    }
 }

--- a/app/src/main/java/io/github/jaehyeonhan/project/entity/Participation.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/entity/Participation.java
@@ -5,6 +5,7 @@ import static io.github.jaehyeonhan.project.util.ValidationUtils.requireNonNull;
 import io.github.jaehyeonhan.project.exception.UnauthorizedPromotionException;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import java.time.Clock;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -28,19 +29,27 @@ public class Participation {
     private LocalDateTime createdAt;
 
     public static Participation joinAsUser(String id, String userId, String chatId) {
-        return new Participation(id, userId, chatId, ParticipationRole.USER);
+        return new Participation(id, userId, chatId, ParticipationRole.USER, Clock.systemDefaultZone());
+    }
+
+    public static Participation joinAsUser(String id, String userId, String chatId, Clock clock) {
+        return new Participation(id, userId, chatId, ParticipationRole.USER, clock);
     }
 
     public static Participation joinAsCreator(String id, String userId, String chatId) {
-        return new Participation(id, userId, chatId, ParticipationRole.CREATOR);
+        return new Participation(id, userId, chatId, ParticipationRole.CREATOR, Clock.systemDefaultZone());
     }
 
-    private Participation(String id, String userId, String chatId, ParticipationRole role) {
+    public static Participation joinAsCreator(String id, String userId, String chatId, Clock clock) {
+        return new Participation(id, userId, chatId, ParticipationRole.CREATOR, clock);
+    }
+
+    private Participation(String id, String userId, String chatId, ParticipationRole role, Clock clock) {
         this.id = requireNonNull(id, "id");
         this.userId = requireNonNull(userId, "user id");
         this.chatId = requireNonNull(chatId, "chat id");
         this.role = requireNonNull(role, "role");
-        createdAt = LocalDateTime.now();
+        createdAt = LocalDateTime.now(clock);
     }
 
     public boolean canBlock(Participation target) {

--- a/app/src/main/java/io/github/jaehyeonhan/project/entity/ParticipationCache.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/entity/ParticipationCache.java
@@ -1,0 +1,10 @@
+package io.github.jaehyeonhan.project.entity;
+
+import java.time.LocalDateTime;
+
+public record ParticipationCache(String id, ParticipationRole role, LocalDateTime createdAt) {
+
+    public Participation toParticipation(String userId, String chatId) {
+        return Participation.restoreFromCache(id, userId, chatId, role, createdAt);
+    }
+}

--- a/app/src/main/java/io/github/jaehyeonhan/project/entity/ParticipationRole.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/entity/ParticipationRole.java
@@ -16,6 +16,6 @@ public enum ParticipationRole {
     }
 
     public boolean canUnblock(ParticipationRole other) {
-        return this.level > other.level;
+        return canBlock(other);
     }
 }

--- a/app/src/main/java/io/github/jaehyeonhan/project/exception/ChatControllerAdvice.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/exception/ChatControllerAdvice.java
@@ -10,24 +10,57 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class ChatControllerAdvice {
 
     @ExceptionHandler
+    public ResponseEntity<String> handleChatNotFoundException(ChatNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<String> handleNotParticipatingException(NotParticipatingException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ex.getMessage());
+    }
+
+    @ExceptionHandler
     public ResponseEntity<String> handleAlreadyBlockedException(AlreadyBlockedException ex) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.getMessage());
     }
 
     @ExceptionHandler
-    public ResponseEntity<String> handleUnauthorizedBlockException(
-        UnauthorizedBlockException ex) {
+    public ResponseEntity<String> handleNotBlockedException(NotBlockedException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<String> handleUnauthorizedBlockException(UnauthorizedBlockException ex) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ex.getMessage());
     }
 
     @ExceptionHandler
-    public ResponseEntity<String> handleUnauthorizedSendMessageException(
-        UnauthorizedSendMessageException ex) {
+    public ResponseEntity<String> handleUnauthorizedUnblockException(UnauthorizedUnblockException ex) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ex.getMessage());
     }
 
     @ExceptionHandler
-    public ResponseEntity<String> handle(InvalidBlockDurationException ex) {
+    public ResponseEntity<String> handleUnauthorizedSendMessageException(UnauthorizedSendMessageException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ex.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<String> handleUnauthorizedPromotionException(UnauthorizedPromotionException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ex.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<String> handleInvalidChatTitleException(InvalidChatTitleException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<String> handleInvalidMessageContentException(InvalidMessageContentException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<String> handleInvalidBlockDurationException(InvalidBlockDurationException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 

--- a/app/src/main/java/io/github/jaehyeonhan/project/exception/ChatControllerAdvice.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/exception/ChatControllerAdvice.java
@@ -1,5 +1,6 @@
 package io.github.jaehyeonhan.project.exception;
 
+import io.github.resilience4j.bulkhead.BulkheadFullException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -28,5 +29,10 @@ public class ChatControllerAdvice {
     @ExceptionHandler
     public ResponseEntity<String> handle(InvalidBlockDurationException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<String> handleBulkheadFullException(BulkheadFullException ex) {
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body("요청이 너무 많습니다. 잠시 후 다시 시도해주세요.");
     }
 }

--- a/app/src/main/java/io/github/jaehyeonhan/project/repository/ParticipationRepository.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/repository/ParticipationRepository.java
@@ -8,4 +8,6 @@ public interface ParticipationRepository {
     Participation save(Participation participation);
 
     Optional<Participation> findByUserIdAndChatId(String userId, String chatId);
+
+    boolean existsByUserIdAndChatId(String userId, String chatId);
 }

--- a/app/src/main/java/io/github/jaehyeonhan/project/repository/jpa/JpaBlockRepository.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/repository/jpa/JpaBlockRepository.java
@@ -1,10 +1,10 @@
 package io.github.jaehyeonhan.project.repository.jpa;
 
 import io.github.jaehyeonhan.project.entity.Block;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface JpaBlockRepository extends JpaRepository<Block, String> {
 

--- a/app/src/main/java/io/github/jaehyeonhan/project/repository/jpa/JpaParticipationRepository.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/repository/jpa/JpaParticipationRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface JpaParticipationRepository extends JpaRepository<Participation, String> {
 
     Optional<Participation> findByUserIdAndChatId(String userId, String chatId);
+
+    boolean existsByUserIdAndChatId(String userId, String chatId);
 }

--- a/app/src/main/java/io/github/jaehyeonhan/project/repository/jpa/ParticipationRepositoryImpl.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/repository/jpa/ParticipationRepositoryImpl.java
@@ -21,4 +21,9 @@ public class ParticipationRepositoryImpl implements ParticipationRepository {
     public Optional<Participation> findByUserIdAndChatId(String userId, String chatId) {
         return jpaParticipationRepository.findByUserIdAndChatId(userId, chatId);
     }
+
+    @Override
+    public boolean existsByUserIdAndChatId(String userId, String chatId) {
+        return jpaParticipationRepository.existsByUserIdAndChatId(userId, chatId);
+    }
 }

--- a/app/src/main/java/io/github/jaehyeonhan/project/service/ChatService.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/service/ChatService.java
@@ -4,29 +4,26 @@ import io.github.jaehyeonhan.project.entity.Block;
 import io.github.jaehyeonhan.project.entity.Chat;
 import io.github.jaehyeonhan.project.entity.Message;
 import io.github.jaehyeonhan.project.entity.Participation;
-import io.github.jaehyeonhan.project.exception.AlreadyBlockedException;
-import io.github.jaehyeonhan.project.exception.ChatNotFoundException;
-import io.github.jaehyeonhan.project.exception.NotBlockedException;
-import io.github.jaehyeonhan.project.exception.NotParticipatingException;
-import io.github.jaehyeonhan.project.exception.UnauthorizedBlockException;
-import io.github.jaehyeonhan.project.exception.UnauthorizedSendMessageException;
-import io.github.jaehyeonhan.project.exception.UnauthorizedUnblockException;
+import io.github.jaehyeonhan.project.exception.*;
 import io.github.jaehyeonhan.project.repository.BlockRepository;
 import io.github.jaehyeonhan.project.repository.ChatRepository;
 import io.github.jaehyeonhan.project.repository.MessageRepository;
 import io.github.jaehyeonhan.project.repository.ParticipationRepository;
 import io.github.jaehyeonhan.project.service.dto.MessageDto;
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class ChatService {
+
+    private final ChatValidationService chatValidationService;
 
     private final ChatRepository chatRepository;
     private final ParticipationRepository participationRepository;
@@ -50,12 +47,10 @@ public class ChatService {
     }
 
     public void join(String userId, String chatId) {
-        requireChat(chatId);
+        chatValidationService.requireChat(chatId);
 
         // 중복 참가 요청은 바로 반환
-        Optional<Participation> optParticipation = participationRepository.findByUserIdAndChatId(
-            userId, chatId);
-        if (optParticipation.isPresent()) {
+        if (participationRepository.existsByUserIdAndChatId(userId, chatId)) {
             return;
         }
 
@@ -64,15 +59,11 @@ public class ChatService {
         participationRepository.save(participation);
     }
 
-    private void requireChat(String chatId) {
-        chatRepository.findById(chatId).orElseThrow(() -> new ChatNotFoundException("채팅이 없습니다."));
-    }
-
     public void sendMessage(String userId, String chatId, String content) {
-        Participation participation = requireParticipation(userId, chatId);
+        Participation participation = chatValidationService.requireParticipation(userId, chatId);
 
         try {
-            validateNotBlocked(participation.getId());
+            chatValidationService.validateNotBlocked(participation.getId());
         } catch (AlreadyBlockedException e) {
             throw new UnauthorizedSendMessageException("차단되어 메시지를 전송할 수 없습니다.");
         }
@@ -83,30 +74,24 @@ public class ChatService {
     }
 
     public List<MessageDto> getMessageList(String userId, String chatId, LocalDateTime lastRead) {
-        requireParticipation(userId, chatId);
+        chatValidationService.requireParticipation(userId, chatId);
 
         return messageRepository.findMessagesAfterLastRead(chatId, lastRead).stream()
                                 .map(MessageDto::from)
                                 .toList();
     }
 
-    private Participation requireParticipation(String userId, String chatId) {
-        return participationRepository.findByUserIdAndChatId(userId, chatId)
-                                      .orElseThrow(
-                                          () -> new NotParticipatingException("참여 중인 채팅이 아닙니다."));
-    }
-
     public void blockUser(String actorUserId, String targetUserId, String chatId,
         int durationInMin) {
-        requireChat(chatId);
-        Participation actor = requireParticipation(actorUserId, chatId);
-        Participation target = requireParticipation(targetUserId, chatId);
+        chatValidationService.requireChat(chatId);
+        Participation actor = chatValidationService.requireParticipation(actorUserId, chatId);
+        Participation target = chatValidationService.requireParticipation(targetUserId, chatId);
 
         if (!actor.canBlock(target)) {
             throw new UnauthorizedBlockException("차단 권한이 없습니다.");
         }
 
-        validateNotBlocked(target.getId());
+        chatValidationService.validateNotBlocked(target.getId());
 
         String blockId = idGenerator.generate();
         Block block = Block.blockFor(blockId, target.getId(), LocalDateTime.now(clock), durationInMin);
@@ -114,9 +99,9 @@ public class ChatService {
     }
 
     public void unblockUser(String actorUserId, String targetUserId, String chatId) {
-        requireChat(chatId);
-        Participation actor = requireParticipation(actorUserId, chatId);
-        Participation target = requireParticipation(targetUserId, chatId);
+        chatValidationService.requireChat(chatId);
+        Participation actor = chatValidationService.requireParticipation(actorUserId, chatId);
+        Participation target = chatValidationService.requireParticipation(targetUserId, chatId);
 
         if (!actor.canUnblock(target)) {
             throw new UnauthorizedUnblockException("차단 해제 권한이 없습니다.");
@@ -127,13 +112,5 @@ public class ChatService {
                                      .orElseThrow(() -> new NotBlockedException("차단 상태가 아닙니다."));
         block.retract();
         blockRepository.save(block);
-    }
-
-    private void validateNotBlocked(String participationId) {
-        Optional<Block> optionalBlock = blockRepository.findActiveBlockByParticipationId(
-            participationId, LocalDateTime.now(clock));
-        if (optionalBlock.isPresent()) {
-            throw new AlreadyBlockedException("차단된 사용자입니다.");
-        }
     }
 }

--- a/app/src/main/java/io/github/jaehyeonhan/project/service/ChatService.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/service/ChatService.java
@@ -10,6 +10,8 @@ import io.github.jaehyeonhan.project.repository.ChatRepository;
 import io.github.jaehyeonhan.project.repository.MessageRepository;
 import io.github.jaehyeonhan.project.repository.ParticipationRepository;
 import io.github.jaehyeonhan.project.service.dto.MessageDto;
+import io.github.resilience4j.bulkhead.annotation.Bulkhead;
+import io.github.resilience4j.bulkhead.annotation.Bulkhead.Type;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -59,6 +60,7 @@ public class ChatService {
         participationRepository.save(participation);
     }
 
+    @Bulkhead(name = "sendMessage", type = Type.SEMAPHORE)
     public void sendMessage(String userId, String chatId, String content) {
         Participation participation = chatValidationService.requireParticipation(userId, chatId);
 

--- a/app/src/main/java/io/github/jaehyeonhan/project/service/ChatService.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/service/ChatService.java
@@ -4,7 +4,11 @@ import io.github.jaehyeonhan.project.entity.Block;
 import io.github.jaehyeonhan.project.entity.Chat;
 import io.github.jaehyeonhan.project.entity.Message;
 import io.github.jaehyeonhan.project.entity.Participation;
-import io.github.jaehyeonhan.project.exception.*;
+import io.github.jaehyeonhan.project.exception.AlreadyBlockedException;
+import io.github.jaehyeonhan.project.exception.NotBlockedException;
+import io.github.jaehyeonhan.project.exception.UnauthorizedBlockException;
+import io.github.jaehyeonhan.project.exception.UnauthorizedSendMessageException;
+import io.github.jaehyeonhan.project.exception.UnauthorizedUnblockException;
 import io.github.jaehyeonhan.project.repository.BlockRepository;
 import io.github.jaehyeonhan.project.repository.ChatRepository;
 import io.github.jaehyeonhan.project.repository.MessageRepository;
@@ -41,12 +45,13 @@ public class ChatService {
         chatRepository.save(chat);
 
         String participationId = idGenerator.generate();
-        Participation participation = Participation.joinAsCreator(participationId, userId, chatId);
+        Participation participation = Participation.joinAsCreator(participationId, userId, chatId, clock);
         participationRepository.save(participation);
 
         return chat.getId();
     }
 
+    @Transactional
     public void join(String userId, String chatId) {
         chatValidationService.requireChat(chatId);
 
@@ -56,11 +61,12 @@ public class ChatService {
         }
 
         String participationId = idGenerator.generate();
-        Participation participation = Participation.joinAsUser(participationId, userId, chatId);
+        Participation participation = Participation.joinAsUser(participationId, userId, chatId, clock);
         participationRepository.save(participation);
     }
 
     @Bulkhead(name = "sendMessage", type = Type.SEMAPHORE)
+    @Transactional
     public void sendMessage(String userId, String chatId, String content) {
         Participation participation = chatValidationService.requireParticipation(userId, chatId);
 
@@ -75,6 +81,7 @@ public class ChatService {
         messageRepository.save(message);
     }
 
+    @Transactional(readOnly = true)
     public List<MessageDto> getMessageList(String userId, String chatId, LocalDateTime lastRead) {
         chatValidationService.requireParticipation(userId, chatId);
 
@@ -83,6 +90,7 @@ public class ChatService {
                                 .toList();
     }
 
+    @Transactional
     public void blockUser(String actorUserId, String targetUserId, String chatId,
         int durationInMin) {
         chatValidationService.requireChat(chatId);
@@ -100,6 +108,7 @@ public class ChatService {
         blockRepository.save(block);
     }
 
+    @Transactional
     public void unblockUser(String actorUserId, String targetUserId, String chatId) {
         chatValidationService.requireChat(chatId);
         Participation actor = chatValidationService.requireParticipation(actorUserId, chatId);

--- a/app/src/main/java/io/github/jaehyeonhan/project/service/ChatValidationService.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/service/ChatValidationService.java
@@ -2,12 +2,12 @@ package io.github.jaehyeonhan.project.service;
 
 import io.github.jaehyeonhan.project.entity.Block;
 import io.github.jaehyeonhan.project.entity.Participation;
+import io.github.jaehyeonhan.project.entity.ParticipationCache;
 import io.github.jaehyeonhan.project.exception.AlreadyBlockedException;
 import io.github.jaehyeonhan.project.exception.ChatNotFoundException;
 import io.github.jaehyeonhan.project.exception.NotParticipatingException;
 import io.github.jaehyeonhan.project.repository.BlockRepository;
 import io.github.jaehyeonhan.project.repository.ChatRepository;
-import io.github.jaehyeonhan.project.repository.ParticipationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,7 +20,7 @@ import java.util.Optional;
 public class ChatValidationService {
 
     private final ChatRepository chatRepository;
-    private final ParticipationRepository participationRepository;
+    private final ParticipationCacheService participationCacheService;
     private final BlockRepository blockRepository;
 
     private final Clock clock;
@@ -30,9 +30,11 @@ public class ChatValidationService {
     }
 
     public Participation requireParticipation(String userId, String chatId) {
-        return participationRepository.findByUserIdAndChatId(userId, chatId)
-            .orElseThrow(
-                () -> new NotParticipatingException("참여 중인 채팅이 아닙니다."));
+        ParticipationCache cache = participationCacheService.get(userId, chatId);
+        if (cache == null) {
+            throw new NotParticipatingException("참여 중인 채팅이 아닙니다.");
+        }
+        return cache.toParticipation(userId, chatId);
     }
 
     public void validateNotBlocked(String participationId) {

--- a/app/src/main/java/io/github/jaehyeonhan/project/service/ChatValidationService.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/service/ChatValidationService.java
@@ -1,0 +1,45 @@
+package io.github.jaehyeonhan.project.service;
+
+import io.github.jaehyeonhan.project.entity.Block;
+import io.github.jaehyeonhan.project.entity.Participation;
+import io.github.jaehyeonhan.project.exception.AlreadyBlockedException;
+import io.github.jaehyeonhan.project.exception.ChatNotFoundException;
+import io.github.jaehyeonhan.project.exception.NotParticipatingException;
+import io.github.jaehyeonhan.project.repository.BlockRepository;
+import io.github.jaehyeonhan.project.repository.ChatRepository;
+import io.github.jaehyeonhan.project.repository.ParticipationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatValidationService {
+
+    private final ChatRepository chatRepository;
+    private final ParticipationRepository participationRepository;
+    private final BlockRepository blockRepository;
+
+    private final Clock clock;
+
+    public void requireChat(String chatId) {
+        chatRepository.findById(chatId).orElseThrow(() -> new ChatNotFoundException("채팅이 없습니다."));
+    }
+
+    public Participation requireParticipation(String userId, String chatId) {
+        return participationRepository.findByUserIdAndChatId(userId, chatId)
+            .orElseThrow(
+                () -> new NotParticipatingException("참여 중인 채팅이 아닙니다."));
+    }
+
+    public void validateNotBlocked(String participationId) {
+        Optional<Block> optionalBlock = blockRepository.findActiveBlockByParticipationId(
+            participationId, LocalDateTime.now(clock));
+        if (optionalBlock.isPresent()) {
+            throw new AlreadyBlockedException("차단된 사용자입니다.");
+        }
+    }
+}

--- a/app/src/main/java/io/github/jaehyeonhan/project/service/ParticipationCacheService.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/service/ParticipationCacheService.java
@@ -7,6 +7,8 @@ import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
 import io.github.jaehyeonhan.project.entity.ParticipationCache;
 import io.github.jaehyeonhan.project.repository.ParticipationRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +25,7 @@ public class ParticipationCacheService {
 
     private final ParticipationRepository participationRepository;
     private final RedisTemplate<String, ParticipationCache> participationRedisTemplate;
+    private final MeterRegistry meterRegistry;
 
     @CircuitBreaker(name = "participationCache", fallbackMethod = "getFallback")
     @Retry(name = "participationCache")
@@ -41,6 +44,10 @@ public class ParticipationCacheService {
 
     // Circuit Open — Redis를 건너뛰고 DB 직접 조회
     private ParticipationCache getFallback(String userId, String chatId, Throwable t) {
+        Counter.builder("participation_cache_fallback")
+            .description("Number of times the participation cache fallback was triggered")
+            .register(meterRegistry)
+            .increment();
         log.warn("participationCache fallback: cause={}", t.getMessage());
         return queryDb(userId, chatId);
     }

--- a/app/src/main/java/io/github/jaehyeonhan/project/service/ParticipationCacheService.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/service/ParticipationCacheService.java
@@ -1,8 +1,5 @@
 package io.github.jaehyeonhan.project.service;
 
-import io.github.resilience4j.bulkhead.BulkheadFullException;
-import io.github.resilience4j.bulkhead.annotation.Bulkhead;
-import io.github.resilience4j.bulkhead.annotation.Bulkhead.Type;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
 import io.github.jaehyeonhan.project.entity.ParticipationCache;
@@ -10,14 +7,12 @@ import io.github.jaehyeonhan.project.repository.ParticipationRepository;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class ParticipationCacheService {
 
     private static final String KEY_PREFIX = "app:participation:";
@@ -25,7 +20,17 @@ public class ParticipationCacheService {
 
     private final ParticipationRepository participationRepository;
     private final RedisTemplate<String, ParticipationCache> participationRedisTemplate;
-    private final MeterRegistry meterRegistry;
+    private final Counter fallbackCounter;
+
+    public ParticipationCacheService(ParticipationRepository participationRepository,
+        RedisTemplate<String, ParticipationCache> participationRedisTemplate,
+        MeterRegistry meterRegistry) {
+        this.participationRepository = participationRepository;
+        this.participationRedisTemplate = participationRedisTemplate;
+        this.fallbackCounter = Counter.builder("participation_cache_fallback")
+            .description("Number of times the participation cache fallback was triggered")
+            .register(meterRegistry);
+    }
 
     @CircuitBreaker(name = "participationCache", fallbackMethod = "getFallback")
     @Retry(name = "participationCache")
@@ -44,10 +49,7 @@ public class ParticipationCacheService {
 
     // Circuit Open — Redis를 건너뛰고 DB 직접 조회
     private ParticipationCache getFallback(String userId, String chatId, Throwable t) {
-        Counter.builder("participation_cache_fallback")
-            .description("Number of times the participation cache fallback was triggered")
-            .register(meterRegistry)
-            .increment();
+        fallbackCounter.increment();
         log.warn("participationCache fallback: cause={}", t.getMessage());
         return queryDb(userId, chatId);
     }

--- a/app/src/main/java/io/github/jaehyeonhan/project/service/ParticipationCacheService.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/service/ParticipationCacheService.java
@@ -1,0 +1,53 @@
+package io.github.jaehyeonhan.project.service;
+
+import io.github.resilience4j.bulkhead.BulkheadFullException;
+import io.github.resilience4j.bulkhead.annotation.Bulkhead;
+import io.github.resilience4j.bulkhead.annotation.Bulkhead.Type;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import io.github.jaehyeonhan.project.entity.ParticipationCache;
+import io.github.jaehyeonhan.project.repository.ParticipationRepository;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ParticipationCacheService {
+
+    private static final String KEY_PREFIX = "app:participation:";
+    private static final Duration TTL = Duration.ofMinutes(5); // TTL은 최악의 상황에서 stale cache를 허용할 수 있는 최대
+
+    private final ParticipationRepository participationRepository;
+    private final RedisTemplate<String, ParticipationCache> participationRedisTemplate;
+
+    @CircuitBreaker(name = "participationCache", fallbackMethod = "getFallback")
+    @Retry(name = "participationCache")
+    public ParticipationCache get(String userId, String chatId) {
+        String key = KEY_PREFIX + userId + ":" + chatId;
+        ParticipationCache cached = participationRedisTemplate.opsForValue().get(key);
+        if (cached != null) {
+            return cached;
+        }
+        ParticipationCache result = queryDb(userId, chatId);
+        if (result != null) {
+            participationRedisTemplate.opsForValue().set(key, result, TTL);
+        }
+        return result;
+    }
+
+    // Circuit Open — Redis를 건너뛰고 DB 직접 조회
+    private ParticipationCache getFallback(String userId, String chatId, Throwable t) {
+        log.warn("participationCache fallback: cause={}", t.getMessage());
+        return queryDb(userId, chatId);
+    }
+
+    private ParticipationCache queryDb(String userId, String chatId) {
+        return participationRepository.findByUserIdAndChatId(userId, chatId)
+            .map(p -> new ParticipationCache(p.getId(), p.getRole(), p.getCreatedAt()))
+            .orElse(null);
+    }
+}

--- a/app/src/main/java/io/github/jaehyeonhan/project/util/ValidationUtils.java
+++ b/app/src/main/java/io/github/jaehyeonhan/project/util/ValidationUtils.java
@@ -2,6 +2,8 @@ package io.github.jaehyeonhan.project.util;
 
 public class ValidationUtils {
 
+    private ValidationUtils() {}
+
     public static <T> T requireNonNull(T value, String name) {
         if (value == null) {
             throw new IllegalArgumentException(name + " should not be null");

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -63,3 +63,16 @@ resilience4j:
       sendMessage:
         max-concurrent-calls: 70
         max-wait-duration: 0ms
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,metrics,circuitbreakers,retries,bulkheads,prometheus
+  health:
+    circuitbreakers:
+      enabled: true
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -30,6 +30,7 @@ spring:
 
 resilience4j:
   circuitbreaker:
+    circuit-breaker-aspect-order: 1
     instances:
       participationCache:
         sliding-window-type: COUNT_BASED
@@ -47,9 +48,9 @@ resilience4j:
           - org.springframework.dao.QueryTimeoutException
       ignore-exceptions:
         - io.github.resilience4j.bulkhead.BulkheadFullException
-      circuit-breaker-aspect-order: 1
 
   retry:
+    retry-aspect-order: 2
     instances:
       participationCache:
         max-attempts: 3
@@ -58,7 +59,6 @@ resilience4j:
           - org.springframework.data.redis.RedisConnectionFailureException
           - org.springframework.data.redis.RedisSystemException
           - org.springframework.dao.QueryTimeoutException
-    retry-aspect-order: 2
 
   bulkhead:
     instances:

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -44,6 +44,7 @@ resilience4j:
         record-exceptions:
           - org.springframework.data.redis.RedisConnectionFailureException
           - org.springframework.data.redis.RedisSystemException
+          - org.springframework.dao.QueryTimeoutException
       ignore-exceptions:
         - io.github.resilience4j.bulkhead.BulkheadFullException
       circuit-breaker-aspect-order: 1
@@ -56,6 +57,7 @@ resilience4j:
         retry-exceptions:
           - org.springframework.data.redis.RedisConnectionFailureException
           - org.springframework.data.redis.RedisSystemException
+          - org.springframework.dao.QueryTimeoutException
     retry-aspect-order: 2
 
   bulkhead:

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -1,9 +1,19 @@
 spring:
+  data:
+    redis:
+      sentinel:
+        master: ${REDIS_SENTINEL_MASTER}
+        nodes: ${REDIS_SENTINEL_NODES}
+      timeout: ${REDIS_TIMEOUT:150ms}
+      connect-timeout: ${REDIS_CONNECTION_TIMEOUT:100ms}
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: ${DB_POOL_SIZE:10}
 
   jpa:
     hibernate:
@@ -17,3 +27,39 @@ spring:
   sql:
     init:
       mode: ${SQL_INIT_MODE:never}
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      participationCache:
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        minimum-number-of-calls: 5
+        failure-rate-threshold: 50
+        slow-call-duration-threshold: 2s
+        slow-call-rate-threshold: 80
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 3
+        automatic-transition-from-open-to-half-open-enabled: true
+        record-exceptions:
+          - org.springframework.data.redis.RedisConnectionFailureException
+          - org.springframework.data.redis.RedisSystemException
+      ignore-exceptions:
+        - io.github.resilience4j.bulkhead.BulkheadFullException
+      circuit-breaker-aspect-order: 1
+
+  retry:
+    instances:
+      participationCache:
+        max-attempts: 3
+        wait-duration: 100ms
+        retry-exceptions:
+          - org.springframework.data.redis.RedisConnectionFailureException
+          - org.springframework.data.redis.RedisSystemException
+    retry-aspect-order: 2
+
+  bulkhead:
+    instances:
+      sendMessage:
+        max-concurrent-calls: 70
+        max-wait-duration: 0ms

--- a/app/src/test/java/io/github/jaehyeonhan/project/ApiTest.java
+++ b/app/src/test/java/io/github/jaehyeonhan/project/ApiTest.java
@@ -1,7 +1,5 @@
 package io.github.jaehyeonhan.project;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.github.jaehyeonhan.project.controller.dto.request.BlockUserRequest;
 import io.github.jaehyeonhan.project.controller.dto.request.CreateChatRequest;
 import io.github.jaehyeonhan.project.controller.dto.request.JoinChatRequest;
@@ -10,9 +8,6 @@ import io.github.jaehyeonhan.project.controller.dto.response.ChatCreatedResponse
 import io.github.jaehyeonhan.project.controller.dto.response.MessageListResponse;
 import io.github.jaehyeonhan.project.service.ChatService;
 import io.github.jaehyeonhan.project.service.IdGenerator;
-import java.net.URI;
-import java.util.Objects;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,6 +20,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Sql("/clear-tables.sql")
@@ -107,7 +107,7 @@ class ApiTest {
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(Objects.requireNonNull(response.getBody()).getMessages().size()).isPositive();
+        assertThat(Objects.requireNonNull(response.getBody()).getMessages()).isNotEmpty();
     }
 
     @Test

--- a/app/src/test/java/io/github/jaehyeonhan/project/config/RedisTestContainerConfig.java
+++ b/app/src/test/java/io/github/jaehyeonhan/project/config/RedisTestContainerConfig.java
@@ -1,0 +1,25 @@
+package io.github.jaehyeonhan.project.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.testcontainers.containers.GenericContainer;
+
+@TestConfiguration
+public class RedisTestContainerConfig {
+
+    static final GenericContainer<?> REDIS =
+        new GenericContainer<>("redis:7").withExposedPorts(6379);
+
+    static {
+        REDIS.start();
+    }
+
+    @Bean
+    @Primary
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(REDIS.getHost(), REDIS.getMappedPort(6379));
+    }
+}

--- a/app/src/test/java/io/github/jaehyeonhan/project/service/ChatServiceIntegrationTest.java
+++ b/app/src/test/java/io/github/jaehyeonhan/project/service/ChatServiceIntegrationTest.java
@@ -38,7 +38,7 @@ import org.springframework.test.context.jdbc.Sql;
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Sql("/clear-tables.sql")
-public class ChatServiceIntegrationTest {
+class ChatServiceIntegrationTest {
 
     @Autowired
     private ChatService chatService;

--- a/app/src/test/java/io/github/jaehyeonhan/project/service/ChatServiceIntegrationTest.java
+++ b/app/src/test/java/io/github/jaehyeonhan/project/service/ChatServiceIntegrationTest.java
@@ -33,15 +33,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import io.github.jaehyeonhan.project.config.RedisTestContainerConfig;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.jdbc.Sql;
 
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Sql("/clear-tables.sql")
+@Import(RedisTestContainerConfig.class)
 class ChatServiceIntegrationTest {
 
     @Autowired

--- a/app/src/test/java/io/github/jaehyeonhan/project/service/ChatServiceIntegrationTest.java
+++ b/app/src/test/java/io/github/jaehyeonhan/project/service/ChatServiceIntegrationTest.java
@@ -16,6 +16,7 @@ import io.github.jaehyeonhan.project.entity.Block;
 import io.github.jaehyeonhan.project.entity.Chat;
 import io.github.jaehyeonhan.project.entity.Message;
 import io.github.jaehyeonhan.project.entity.Participation;
+import io.github.jaehyeonhan.project.entity.ParticipationCache;
 import io.github.jaehyeonhan.project.entity.ParticipationRole;
 import io.github.jaehyeonhan.project.exception.ChatNotFoundException;
 import io.github.jaehyeonhan.project.exception.InvalidChatTitleException;
@@ -27,12 +28,15 @@ import io.github.jaehyeonhan.project.repository.ParticipationRepository;
 import io.github.jaehyeonhan.project.service.dto.MessageDto;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.jdbc.Sql;
 
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
@@ -54,6 +58,17 @@ class ChatServiceIntegrationTest {
 
     @Autowired
     private BlockRepository blockRepository;
+
+    @Autowired
+    private RedisTemplate<String, ParticipationCache> participationRedisTemplate;
+
+    @BeforeEach
+    void clearRedisCache() {
+        Set<String> keys = participationRedisTemplate.keys("app:participation:*");
+        if (keys != null && !keys.isEmpty()) {
+            participationRedisTemplate.delete(keys);
+        }
+    }
 
     @Test
     @DisplayName("채팅 정상 생성 시 chat이 생성되고, 요청자가 참가자로 추가된다.")

--- a/app/src/test/java/io/github/jaehyeonhan/project/service/ChatServiceTest.java
+++ b/app/src/test/java/io/github/jaehyeonhan/project/service/ChatServiceTest.java
@@ -250,8 +250,8 @@ class ChatServiceTest {
         Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID, CHAT_ID);
         Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID, CHAT_ID);
 
-        given(chatValidationService.requireParticipation(eq(USER_ID), eq(CHAT_ID))).willReturn(creator);
-        given(chatValidationService.requireParticipation(eq(ANOTHER_USER_ID), eq(CHAT_ID))).willReturn(user);
+        given(chatValidationService.requireParticipation(USER_ID, CHAT_ID)).willReturn(creator);
+        given(chatValidationService.requireParticipation(ANOTHER_USER_ID, CHAT_ID)).willReturn(user);
 
         // when, then
         assertThatThrownBy(() -> {
@@ -269,8 +269,8 @@ class ChatServiceTest {
         String manager2ParticipationId = "449388e5-1544-48cc-91e0-8c2363713236";
         Participation manager2 = getManager(creator, manager2ParticipationId, THE_OTHER_USER_ID);
 
-        given(chatValidationService.requireParticipation(eq(ANOTHER_USER_ID), eq(CHAT_ID))).willReturn(manager1);
-        given(chatValidationService.requireParticipation(eq(THE_OTHER_USER_ID), eq(CHAT_ID))).willReturn(manager2);
+        given(chatValidationService.requireParticipation(ANOTHER_USER_ID, CHAT_ID)).willReturn(manager1);
+        given(chatValidationService.requireParticipation(THE_OTHER_USER_ID, CHAT_ID)).willReturn(manager2);
 
         // when, then
         assertThatThrownBy(
@@ -286,8 +286,8 @@ class ChatServiceTest {
         Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID, CHAT_ID);
         Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID, CHAT_ID);
 
-        given(chatValidationService.requireParticipation(eq(USER_ID), eq(CHAT_ID))).willReturn(creator);
-        given(chatValidationService.requireParticipation(eq(ANOTHER_USER_ID), eq(CHAT_ID))).willReturn(user);
+        given(chatValidationService.requireParticipation(USER_ID, CHAT_ID)).willReturn(creator);
+        given(chatValidationService.requireParticipation(ANOTHER_USER_ID, CHAT_ID)).willReturn(user);
 
         // when, then
         assertThatThrownBy(() -> {
@@ -302,15 +302,15 @@ class ChatServiceTest {
         Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID, CHAT_ID);
         Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID, CHAT_ID);
 
-        given(chatValidationService.requireParticipation(eq(USER_ID), eq(CHAT_ID))).willReturn(creator);
-        given(chatValidationService.requireParticipation(eq(ANOTHER_USER_ID), eq(CHAT_ID))).willReturn(user);
+        given(chatValidationService.requireParticipation(USER_ID, CHAT_ID)).willReturn(creator);
+        given(chatValidationService.requireParticipation(ANOTHER_USER_ID, CHAT_ID)).willReturn(user);
         willThrow(new AlreadyBlockedException("차단된 사용자입니다."))
             .given(chatValidationService).validateNotBlocked(user.getId());
 
         // when, then
         assertThatThrownBy(() -> {
             chatService.blockUser(creator.getUserId(), user.getUserId(), CHAT_ID, VALID_BLOCK_DURATION);
-        });
+        }).isInstanceOf(AlreadyBlockedException.class);
     }
 
     @Test
@@ -338,8 +338,8 @@ class ChatServiceTest {
         Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID, CHAT_ID);
         Block block = Block.blockFor(BLOCK_ID, user.getId(), LocalDateTime.now(), VALID_BLOCK_DURATION);
 
-        given(chatValidationService.requireParticipation(eq(USER_ID), eq(CHAT_ID))).willReturn(creator);
-        given(chatValidationService.requireParticipation(eq(ANOTHER_USER_ID), eq(CHAT_ID))).willReturn(user);
+        given(chatValidationService.requireParticipation(USER_ID, CHAT_ID)).willReturn(creator);
+        given(chatValidationService.requireParticipation(ANOTHER_USER_ID, CHAT_ID)).willReturn(user);
         given(blockRepository.findActiveBlockByParticipationId(eq(user.getId()), any(LocalDateTime.class)))
             .willReturn(Optional.of(block));
 
@@ -358,8 +358,8 @@ class ChatServiceTest {
         Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID, CHAT_ID);
         Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID, CHAT_ID);
 
-        given(chatValidationService.requireParticipation(eq(USER_ID), eq(CHAT_ID))).willReturn(creator);
-        given(chatValidationService.requireParticipation(eq(ANOTHER_USER_ID), eq(CHAT_ID))).willReturn(user);
+        given(chatValidationService.requireParticipation(USER_ID, CHAT_ID)).willReturn(creator);
+        given(chatValidationService.requireParticipation(ANOTHER_USER_ID, CHAT_ID)).willReturn(user);
         given(blockRepository.findActiveBlockByParticipationId(eq(user.getId()), any(LocalDateTime.class)))
             .willReturn(Optional.empty());
 
@@ -376,8 +376,8 @@ class ChatServiceTest {
         Participation user1 = Participation.joinAsUser(PARTICIPATION_ID, ANOTHER_USER_ID, CHAT_ID);
         Participation user2 = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, THE_OTHER_USER_ID, CHAT_ID);
 
-        given(chatValidationService.requireParticipation(eq(user1.getUserId()), eq(CHAT_ID))).willReturn(user1);
-        given(chatValidationService.requireParticipation(eq(user2.getUserId()), eq(CHAT_ID))).willReturn(user2);
+        given(chatValidationService.requireParticipation(user1.getUserId(), CHAT_ID)).willReturn(user1);
+        given(chatValidationService.requireParticipation(user2.getUserId(), CHAT_ID)).willReturn(user2);
 
         // when, then
         assertThatThrownBy(() -> {

--- a/app/src/test/java/io/github/jaehyeonhan/project/service/ChatServiceTest.java
+++ b/app/src/test/java/io/github/jaehyeonhan/project/service/ChatServiceTest.java
@@ -17,13 +17,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.github.jaehyeonhan.project.entity.Block;
-import io.github.jaehyeonhan.project.entity.Chat;
 import io.github.jaehyeonhan.project.entity.Message;
 import io.github.jaehyeonhan.project.entity.Participation;
+import io.github.jaehyeonhan.project.entity.Chat;
+import io.github.jaehyeonhan.project.exception.AlreadyBlockedException;
 import io.github.jaehyeonhan.project.exception.ChatNotFoundException;
 import io.github.jaehyeonhan.project.exception.InvalidBlockDurationException;
 import io.github.jaehyeonhan.project.exception.InvalidChatTitleException;
@@ -56,6 +58,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ChatServiceTest {
 
     @Mock
+    private ChatValidationService chatValidationService;
+
+    @Mock
     private ChatRepository chatRepository;
 
     @Mock
@@ -86,8 +91,7 @@ class ChatServiceTest {
     void given_title_when_create_then_createChatAndRequesterJoinsChatAndReturnsChatId() {
         // given
         Chat chat = new Chat(CHAT_ID, USER_ID, "test");
-        Participation participation = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID,
-            CHAT_ID);
+        Participation participation = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID, CHAT_ID);
 
         given(idGenerator.generate()).willReturn(CHAT_ID, PARTICIPATION_ID);
         given(chatRepository.save(any(Chat.class))).willReturn(chat);
@@ -117,12 +121,9 @@ class ChatServiceTest {
     @DisplayName("채팅이 존재하고 처음 참가 시 채팅에 참가한다.")
     void given_chatExistsAndNotJoined_when_join_then_userJoinsChat() {
         // given
-        Chat chat = new Chat(CHAT_ID, ANOTHER_USER_ID, "title");
         Participation participation = Participation.joinAsUser(PARTICIPATION_ID, USER_ID, CHAT_ID);
 
-        given(chatRepository.findById(CHAT_ID)).willReturn(Optional.of(chat));
-        given(participationRepository.findByUserIdAndChatId(USER_ID, CHAT_ID)).willReturn(
-            Optional.empty());
+        given(participationRepository.existsByUserIdAndChatId(USER_ID, CHAT_ID)).willReturn(false);
         given(idGenerator.generate()).willReturn(PARTICIPATION_ID);
         given(participationRepository.save(any(Participation.class))).willReturn(participation);
 
@@ -137,12 +138,9 @@ class ChatServiceTest {
     @DisplayName("채팅에 중복으로 참여해도 참여 기록은 한 번만 생성된다.")
     void given_chatExists_when_joinParticipatingChat_then_oneParticipationIsCreated() {
         // given
-        Chat chat = new Chat(CHAT_ID, ANOTHER_USER_ID, "title");
         Participation participation = Participation.joinAsUser(PARTICIPATION_ID, USER_ID, CHAT_ID);
 
-        given(chatRepository.findById(ChatTestConst.CHAT_ID)).willReturn(Optional.of(chat));
-        given(participationRepository.findByUserIdAndChatId(USER_ID, CHAT_ID)).willReturn(
-            Optional.empty(), Optional.of(participation));
+        given(participationRepository.existsByUserIdAndChatId(USER_ID, CHAT_ID)).willReturn(false, true);
         given(idGenerator.generate()).willReturn(PARTICIPATION_ID);
         given(participationRepository.save(any(Participation.class))).willReturn(participation);
 
@@ -158,7 +156,8 @@ class ChatServiceTest {
     @DisplayName("존재하지 않는 채팅에 참여할 시 예외가 발생한다.")
     void given_chatNotExists_when_join_then_throwException() {
         // given
-        given(chatRepository.findById(NON_EXISTENT_CHAT_ID)).willReturn(Optional.empty());
+        willThrow(new ChatNotFoundException("채팅이 없습니다."))
+            .given(chatValidationService).requireChat(NON_EXISTENT_CHAT_ID);
 
         // when, then
         assertThatThrownBy(() -> chatService.join(USER_ID, NON_EXISTENT_CHAT_ID))
@@ -170,11 +169,9 @@ class ChatServiceTest {
     void given_userJoinedChat_when_sendMessage_then_messageIsSaved() {
         // given
         Message message = new Message(MESSAGE_ID, CHAT_ID, USER_ID, "content", LocalDateTime.now());
-        Participation participation = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID,
-            CHAT_ID);
+        Participation participation = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID, CHAT_ID);
 
-        given(participationRepository.findByUserIdAndChatId(USER_ID, CHAT_ID)).willReturn(
-            Optional.of(participation));
+        given(chatValidationService.requireParticipation(USER_ID, CHAT_ID)).willReturn(participation);
         given(idGenerator.generate()).willReturn(MESSAGE_ID);
         given(messageRepository.save(any(Message.class))).willReturn(message);
 
@@ -189,8 +186,8 @@ class ChatServiceTest {
     @DisplayName("참여하지 않은 채팅에 메시지 전송 시 예외가 발생한다.")
     void given_userNotJoinedChat_when_sendMessage_then_throwException() {
         // given
-        given(participationRepository.findByUserIdAndChatId(USER_ID,
-            CHAT_ID)).willReturn(Optional.empty());
+        given(chatValidationService.requireParticipation(USER_ID, CHAT_ID))
+            .willThrow(new NotParticipatingException("참여 중인 채팅이 아닙니다."));
 
         // when, then
         assertThatThrownBy(() -> chatService.sendMessage(USER_ID, CHAT_ID, "content"))
@@ -201,18 +198,14 @@ class ChatServiceTest {
     @DisplayName("참여한 채팅의 새 메시지 조회 시 메시지를 응답한다.")
     void given_userJoinedChat_when_getNewMessage_then_messageListIsReturned() {
         // given
-        Participation participation = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID,
-            CHAT_ID);
+        Participation participation = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID, CHAT_ID);
         Message message = new Message(MESSAGE_ID, CHAT_ID, USER_ID, "content", LocalDateTime.now());
 
-        given(participationRepository.findByUserIdAndChatId(USER_ID, CHAT_ID)).willReturn(
-            Optional.of(participation));
-        given(messageRepository.findMessagesAfterLastRead(CHAT_ID,
-            BEGINNING_OF_TIME)).willReturn(List.of(message));
+        given(chatValidationService.requireParticipation(USER_ID, CHAT_ID)).willReturn(participation);
+        given(messageRepository.findMessagesAfterLastRead(CHAT_ID, BEGINNING_OF_TIME)).willReturn(List.of(message));
 
         // when
-        List<MessageDto> newMessageList = chatService.getMessageList(USER_ID, CHAT_ID,
-            BEGINNING_OF_TIME);
+        List<MessageDto> newMessageList = chatService.getMessageList(USER_ID, CHAT_ID, BEGINNING_OF_TIME);
 
         // then
         assertThat(newMessageList).anyMatch(d -> d.getId().equals(MESSAGE_ID));
@@ -222,8 +215,8 @@ class ChatServiceTest {
     @DisplayName("참여하지 않은 채팅의 새 메시지 조회 시 예외가 발생한다.")
     void given_userNotJoinedChat_when_getNewMessage_then_throwException() {
         // given
-        given(participationRepository.findByUserIdAndChatId(USER_ID, CHAT_ID)).willReturn(
-            Optional.empty());
+        given(chatValidationService.requireParticipation(USER_ID, CHAT_ID))
+            .willThrow(new NotParticipatingException("참여 중인 채팅이 아닙니다."));
 
         // when, then
         assertThatThrownBy(() -> chatService.getMessageList(USER_ID, CHAT_ID, BEGINNING_OF_TIME))
@@ -235,16 +228,11 @@ class ChatServiceTest {
     void given_chatCreatorAndManager_when_blockUser_then_userIsBlocked() {
         // given
         ArgumentCaptor<Block> captor = ArgumentCaptor.forClass(Block.class);
-        Chat chat = new Chat(CHAT_ID, USER_ID, "title");
-        Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID,
-            CHAT_ID);
-        Participation user = Participation.joinAsUser(PARTICIPATION_ID, ANOTHER_USER_ID, CHAT_ID);
+        Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID, CHAT_ID);
+        Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID, CHAT_ID);
 
-        given(chatRepository.findById(CHAT_ID)).willReturn(Optional.of(chat));
-        given(participationRepository.findByUserIdAndChatId(eq(USER_ID), eq(CHAT_ID))).willReturn(
-            Optional.of(creator));
-        given(participationRepository.findByUserIdAndChatId(eq(ANOTHER_USER_ID),
-            eq(CHAT_ID))).willReturn(Optional.of(user));
+        given(chatValidationService.requireParticipation((USER_ID), (CHAT_ID))).willReturn(creator);
+        given(chatValidationService.requireParticipation((ANOTHER_USER_ID), (CHAT_ID))).willReturn(user);
         given(idGenerator.generate()).willReturn(BLOCK_ID);
 
         // when
@@ -259,22 +247,15 @@ class ChatServiceTest {
     @DisplayName("일반 참가자는 다른 참가자의 메시지 전송을 차단할 수 없다.")
     void given_user_when_blocksOthers_then_throwException() {
         // given
-        Chat chat = new Chat(CHAT_ID, USER_ID, "title");
-        Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID,
-            CHAT_ID);
-        Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID,
-            CHAT_ID);
+        Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID, CHAT_ID);
+        Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID, CHAT_ID);
 
-        given(chatRepository.findById(CHAT_ID)).willReturn(Optional.of(chat));
-        given(participationRepository.findByUserIdAndChatId(eq(USER_ID), eq(CHAT_ID))).willReturn(
-            Optional.of(creator));
-        given(participationRepository.findByUserIdAndChatId(eq(ANOTHER_USER_ID),
-            eq(CHAT_ID))).willReturn(Optional.of(user));
+        given(chatValidationService.requireParticipation(eq(USER_ID), eq(CHAT_ID))).willReturn(creator);
+        given(chatValidationService.requireParticipation(eq(ANOTHER_USER_ID), eq(CHAT_ID))).willReturn(user);
 
         // when, then
         assertThatThrownBy(() -> {
-            chatService.blockUser(user.getUserId(), creator.getUserId(), CHAT_ID,
-                VALID_BLOCK_DURATION);
+            chatService.blockUser(user.getUserId(), creator.getUserId(), CHAT_ID, VALID_BLOCK_DURATION);
         }).isInstanceOf(UnauthorizedBlockException.class);
     }
 
@@ -282,25 +263,18 @@ class ChatServiceTest {
     @DisplayName("관리자는 서로의 메시지 전송을 차단할 수 없다.")
     void given_chatManager_when_blockEachOther_then_throwException() {
         // given
-        Chat chat = new Chat(CHAT_ID, USER_ID, "title");
-        Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID,
-            CHAT_ID);
+        Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID, CHAT_ID);
         String manager1ParticipationId = "619da13e-8564-43b1-9913-fbabfe6c61c1";
         Participation manager1 = getManager(creator, manager1ParticipationId, ANOTHER_USER_ID);
         String manager2ParticipationId = "449388e5-1544-48cc-91e0-8c2363713236";
         Participation manager2 = getManager(creator, manager2ParticipationId, THE_OTHER_USER_ID);
 
-        given(chatRepository.findById(CHAT_ID)).willReturn(Optional.of(chat));
-        given(participationRepository.findByUserIdAndChatId(eq(ANOTHER_USER_ID),
-            eq(CHAT_ID))).willReturn(
-            Optional.of(manager1));
-        given(participationRepository.findByUserIdAndChatId(eq(THE_OTHER_USER_ID),
-            eq(CHAT_ID))).willReturn(Optional.of(manager2));
+        given(chatValidationService.requireParticipation(eq(ANOTHER_USER_ID), eq(CHAT_ID))).willReturn(manager1);
+        given(chatValidationService.requireParticipation(eq(THE_OTHER_USER_ID), eq(CHAT_ID))).willReturn(manager2);
 
         // when, then
         assertThatThrownBy(
-            () -> chatService.blockUser(manager1.getUserId(), manager2.getUserId(), chat.getId(),
-                VALID_BLOCK_DURATION))
+            () -> chatService.blockUser(manager1.getUserId(), manager2.getUserId(), CHAT_ID, VALID_BLOCK_DURATION))
             .isInstanceOf(UnauthorizedBlockException.class);
     }
 
@@ -309,22 +283,15 @@ class ChatServiceTest {
     @DisplayName("일시 차단은 5분 이상 30분 이하만 가능하다.")
     void whenBlockDurationOutOfRange_thenThrowException(int duration) {
         // given
-        Chat chat = new Chat(CHAT_ID, USER_ID, "title");
-        Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID,
-            CHAT_ID);
-        Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID,
-            CHAT_ID);
+        Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID, CHAT_ID);
+        Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID, CHAT_ID);
 
-        given(chatRepository.findById(CHAT_ID)).willReturn(Optional.of(chat));
-        given(participationRepository.findByUserIdAndChatId(eq(USER_ID), eq(CHAT_ID))).willReturn(
-            Optional.of(creator));
-        given(participationRepository.findByUserIdAndChatId(eq(ANOTHER_USER_ID),
-            eq(CHAT_ID))).willReturn(Optional.of(user));
-        given(idGenerator.generate()).willReturn(BLOCK_ID);
+        given(chatValidationService.requireParticipation(eq(USER_ID), eq(CHAT_ID))).willReturn(creator);
+        given(chatValidationService.requireParticipation(eq(ANOTHER_USER_ID), eq(CHAT_ID))).willReturn(user);
 
         // when, then
         assertThatThrownBy(() -> {
-            chatService.blockUser(creator.getUserId(), user.getUserId(), chat.getId(), duration);
+            chatService.blockUser(creator.getUserId(), user.getUserId(), CHAT_ID, duration);
         }).isInstanceOf(InvalidBlockDurationException.class);
     }
 
@@ -332,26 +299,17 @@ class ChatServiceTest {
     @DisplayName("차단 상태의 사용자를 다시 차단할 수 없다.")
     void when_blockAlreadyBlockedUser_then_throwException() {
         // given
-        Chat chat = new Chat(CHAT_ID, USER_ID, "title");
-        Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID,
-            CHAT_ID);
-        Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID,
-            CHAT_ID);
-        Block block = Block.blockFor(BLOCK_ID, user.getId(), LocalDateTime.now(), VALID_BLOCK_DURATION);
+        Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID, CHAT_ID);
+        Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID, CHAT_ID);
 
-        given(chatRepository.findById(CHAT_ID)).willReturn(Optional.of(chat));
-        given(participationRepository.findByUserIdAndChatId(eq(USER_ID), eq(CHAT_ID))).willReturn(
-            Optional.of(creator));
-        given(participationRepository.findByUserIdAndChatId(eq(ANOTHER_USER_ID),
-            eq(CHAT_ID))).willReturn(Optional.of(user));
-        given(blockRepository.findActiveBlockByParticipationId(user.getId(),
-            LocalDateTime.now())).willReturn(
-            Optional.of(block));
+        given(chatValidationService.requireParticipation(eq(USER_ID), eq(CHAT_ID))).willReturn(creator);
+        given(chatValidationService.requireParticipation(eq(ANOTHER_USER_ID), eq(CHAT_ID))).willReturn(user);
+        willThrow(new AlreadyBlockedException("차단된 사용자입니다."))
+            .given(chatValidationService).validateNotBlocked(user.getId());
 
         // when, then
         assertThatThrownBy(() -> {
-            chatService.blockUser(creator.getUserId(), user.getUserId(), chat.getId(),
-                VALID_BLOCK_DURATION);
+            chatService.blockUser(creator.getUserId(), user.getUserId(), CHAT_ID, VALID_BLOCK_DURATION);
         });
     }
 
@@ -359,21 +317,15 @@ class ChatServiceTest {
     @DisplayName("차단된 사용자는 메시지를 전송할 수 없다.")
     void given_blockedUser_when_sendMessage_then_throwException() {
         // given
-        Chat chat = new Chat(CHAT_ID, USER_ID, "title");
-        Participation blockedUser = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID,
-            ANOTHER_USER_ID, chat.getId());
-        Block block = Block.blockFor(BLOCK_ID, blockedUser.getId(), LocalDateTime.now(), 0);
+        Participation blockedUser = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID, CHAT_ID);
 
-        given(participationRepository.findByUserIdAndChatId(blockedUser.getUserId(),
-            chat.getId())).willReturn(
-            Optional.of(blockedUser));
-        given(blockRepository.findActiveBlockByParticipationId(eq(blockedUser.getId()),
-            any(LocalDateTime.class))).willReturn(
-            Optional.of(block));
+        given(chatValidationService.requireParticipation(blockedUser.getUserId(), CHAT_ID)).willReturn(blockedUser);
+        willThrow(new AlreadyBlockedException("차단된 사용자입니다."))
+            .given(chatValidationService).validateNotBlocked(blockedUser.getId());
 
         // when, then
         assertThatThrownBy(() -> {
-            chatService.sendMessage(blockedUser.getUserId(), chat.getId(), "message");
+            chatService.sendMessage(blockedUser.getUserId(), CHAT_ID, "message");
         }).isInstanceOf(UnauthorizedSendMessageException.class);
     }
 
@@ -382,25 +334,17 @@ class ChatServiceTest {
     void given_blockedUser_when_unblock_then_retractBlock() {
         // given
         ArgumentCaptor<Block> captor = ArgumentCaptor.forClass(Block.class);
-        Chat chat = new Chat(CHAT_ID, USER_ID, "title");
-        Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID,
-            CHAT_ID);
-        Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID,
-            CHAT_ID);
+        Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID, CHAT_ID);
+        Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID, CHAT_ID);
         Block block = Block.blockFor(BLOCK_ID, user.getId(), LocalDateTime.now(), VALID_BLOCK_DURATION);
 
-        given(chatRepository.findById(CHAT_ID)).willReturn(Optional.of(chat));
-        given(participationRepository.findByUserIdAndChatId(eq(USER_ID), eq(CHAT_ID))).willReturn(
-            Optional.of(creator));
-        given(participationRepository.findByUserIdAndChatId(eq(ANOTHER_USER_ID),
-            eq(CHAT_ID))).willReturn(Optional.of(user));
-        given(blockRepository.findActiveBlockByParticipationId(eq(user.getId()),
-            any(LocalDateTime.class))).willReturn(
-            Optional.of(
-                block)); // fixme: potential regression not verifying calling LocalDateTime.now()
+        given(chatValidationService.requireParticipation(eq(USER_ID), eq(CHAT_ID))).willReturn(creator);
+        given(chatValidationService.requireParticipation(eq(ANOTHER_USER_ID), eq(CHAT_ID))).willReturn(user);
+        given(blockRepository.findActiveBlockByParticipationId(eq(user.getId()), any(LocalDateTime.class)))
+            .willReturn(Optional.of(block));
 
         // when
-        chatService.unblockUser(creator.getUserId(), user.getUserId(), chat.getId());
+        chatService.unblockUser(creator.getUserId(), user.getUserId(), CHAT_ID);
 
         // then
         then(blockRepository).should().save(captor.capture());
@@ -411,23 +355,17 @@ class ChatServiceTest {
     @DisplayName("차단되지 않은 참가자를 차단 해제할 수 없다.")
     void given_notBlockedUser_when_unblock_then_throwException() {
         // given
-        Chat chat = new Chat(CHAT_ID, USER_ID, "title");
-        Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID,
-            CHAT_ID);
-        Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID,
-            CHAT_ID);
+        Participation creator = Participation.joinAsCreator(PARTICIPATION_ID, USER_ID, CHAT_ID);
+        Participation user = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, ANOTHER_USER_ID, CHAT_ID);
 
-        given(chatRepository.findById(CHAT_ID)).willReturn(Optional.of(chat));
-        given(participationRepository.findByUserIdAndChatId(eq(USER_ID), eq(CHAT_ID))).willReturn(
-            Optional.of(creator));
-        given(participationRepository.findByUserIdAndChatId(eq(ANOTHER_USER_ID),
-            eq(CHAT_ID))).willReturn(Optional.of(user));
-        given(blockRepository.findActiveBlockByParticipationId(eq(user.getId()),
-            any(LocalDateTime.class))).willReturn(Optional.empty());
+        given(chatValidationService.requireParticipation(eq(USER_ID), eq(CHAT_ID))).willReturn(creator);
+        given(chatValidationService.requireParticipation(eq(ANOTHER_USER_ID), eq(CHAT_ID))).willReturn(user);
+        given(blockRepository.findActiveBlockByParticipationId(eq(user.getId()), any(LocalDateTime.class)))
+            .willReturn(Optional.empty());
 
         // when, then
         assertThatThrownBy(() -> {
-            chatService.unblockUser(creator.getUserId(), user.getUserId(), chat.getId());
+            chatService.unblockUser(creator.getUserId(), user.getUserId(), CHAT_ID);
         }).isInstanceOf(NotBlockedException.class);
     }
 
@@ -435,28 +373,20 @@ class ChatServiceTest {
     @DisplayName("일반 참가자는 다른 참가자의 차단을 해제할 수 없다")
     void given_notAuthorizedUser_when_unblock_then_throwException() {
         // given
-        Chat chat = new Chat(CHAT_ID, USER_ID, "title");
-        Participation user1 = Participation.joinAsUser(PARTICIPATION_ID, ANOTHER_USER_ID,
-            CHAT_ID);
-        Participation user2 = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, THE_OTHER_USER_ID,
-            CHAT_ID);
+        Participation user1 = Participation.joinAsUser(PARTICIPATION_ID, ANOTHER_USER_ID, CHAT_ID);
+        Participation user2 = Participation.joinAsUser(ANOTHER_PARTICIPATION_ID, THE_OTHER_USER_ID, CHAT_ID);
 
-        given(chatRepository.findById(CHAT_ID)).willReturn(Optional.of(chat));
-        given(participationRepository.findByUserIdAndChatId(eq(user1.getUserId()),
-            eq(chat.getId()))).willReturn(
-            Optional.of(user1));
-        given(participationRepository.findByUserIdAndChatId(eq(user2.getUserId()),
-            eq(chat.getId()))).willReturn(Optional.of(user2));
+        given(chatValidationService.requireParticipation(eq(user1.getUserId()), eq(CHAT_ID))).willReturn(user1);
+        given(chatValidationService.requireParticipation(eq(user2.getUserId()), eq(CHAT_ID))).willReturn(user2);
 
         // when, then
         assertThatThrownBy(() -> {
-            chatService.unblockUser(user1.getUserId(), user2.getUserId(), chat.getId());
+            chatService.unblockUser(user1.getUserId(), user2.getUserId(), CHAT_ID);
         }).isInstanceOf(UnauthorizedUnblockException.class);
     }
 
     private Participation getManager(Participation creator, String participationId, String userId) {
-        Participation manager = Participation.joinAsUser(participationId, userId,
-            creator.getChatId());
+        Participation manager = Participation.joinAsUser(participationId, userId, creator.getChatId());
         creator.promoteToManager(manager);
         return manager;
     }

--- a/app/src/test/java/io/github/jaehyeonhan/project/service/ParticipationCacheResilienceIntegrationTest.java
+++ b/app/src/test/java/io/github/jaehyeonhan/project/service/ParticipationCacheResilienceIntegrationTest.java
@@ -1,0 +1,144 @@
+package io.github.jaehyeonhan.project.service;
+
+import io.github.jaehyeonhan.project.entity.Participation;
+import io.github.jaehyeonhan.project.entity.ParticipationCache;
+import io.github.jaehyeonhan.project.entity.ParticipationRole;
+import io.github.jaehyeonhan.project.repository.ParticipationRepository;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static io.github.jaehyeonhan.project.service.ChatTestConst.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class ParticipationCacheResilienceIntegrationTest {
+
+    @Autowired
+    ParticipationCacheService participationCacheService;
+
+    @Autowired
+    CircuitBreakerRegistry circuitBreakerRegistry;
+
+    @MockitoBean
+    ParticipationRepository participationRepository;
+
+    @MockitoBean
+    RedisTemplate<String, ParticipationCache> participationRedisTemplate;
+
+    @MockitoBean
+    ValueOperations<String, ParticipationCache> valueOperations;
+
+    @BeforeEach
+    void setUp() {
+        given(participationRedisTemplate.opsForValue())
+            .willReturn(valueOperations);
+
+        circuitBreakerRegistry
+            .circuitBreaker("participationCache")
+            .reset();
+    }
+
+    @Test
+    @DisplayName("Redis 일시 실패 시 retry 후 성공한다.")
+    void given_temporaryRedisFailure_when_get_then_retryAndSucceed() {
+
+        // given
+        String key = "app:participation:" + USER_ID + ":" + CHAT_ID;
+
+        ParticipationCache cached = new ParticipationCache(
+            PARTICIPATION_ID,
+            ParticipationRole.USER,
+            LocalDateTime.now()
+        );
+
+        given(valueOperations.get(key))
+            .willThrow(new RedisConnectionFailureException("redis fail"))
+            .willThrow(new RedisConnectionFailureException("redis fail"))
+            .willReturn(cached);
+
+        // when
+        ParticipationCache result = participationCacheService.get(USER_ID, CHAT_ID);
+
+        // then
+        then(valueOperations)
+            .should(times(3))
+            .get(key);
+
+        assertThat(result).isEqualTo(cached);
+    }
+
+    @Test
+    @DisplayName("Redis 실패가 반복되면 CircuitBreaker가 OPEN 된다.")
+    void given_repeatedRedisFailure_when_get_then_openCircuitBreaker() {
+
+        // given
+        String key = "app:participation:" + USER_ID + ":" + CHAT_ID;
+
+        given(valueOperations.get(key))
+            .willThrow(new RedisConnectionFailureException("redis failure"));
+
+        given(participationRepository.findByUserIdAndChatId(USER_ID, CHAT_ID))
+            .willReturn(Optional.empty());
+
+        CircuitBreaker circuitBreaker =
+            circuitBreakerRegistry.circuitBreaker("participationCache");
+
+        // when
+        for (int i = 0; i < 10; i++) {
+            participationCacheService.get(USER_ID, CHAT_ID);
+        }
+
+        // then
+        assertThat(circuitBreaker.getState())
+            .isEqualTo(CircuitBreaker.State.OPEN);
+    }
+
+    @Test
+    @DisplayName("CircuitBreaker OPEN 상태에서는 Redis를 호출하지 않고 fallback DB 조회만 수행한다.")
+    void given_circuitBreakerOpen_when_get_then_skipRedisAndQueryDbFallback() {
+
+        // given
+        CircuitBreaker circuitBreaker =
+            circuitBreakerRegistry.circuitBreaker("participationCache");
+
+        circuitBreaker.transitionToOpenState();
+
+        Participation participation = Participation.joinAsUser(
+            PARTICIPATION_ID,
+            USER_ID,
+            CHAT_ID
+        );
+
+        given(participationRepository.findByUserIdAndChatId(USER_ID, CHAT_ID))
+            .willReturn(Optional.of(participation));
+
+        // when
+        ParticipationCache result = participationCacheService.get(USER_ID, CHAT_ID);
+
+        // then
+        then(valueOperations)
+            .shouldHaveNoInteractions();
+
+        then(participationRepository)
+            .should(times(1))
+            .findByUserIdAndChatId(USER_ID, CHAT_ID);
+
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(PARTICIPATION_ID);
+    }
+}

--- a/app/src/test/java/io/github/jaehyeonhan/project/service/ParticipationCacheTest.java
+++ b/app/src/test/java/io/github/jaehyeonhan/project/service/ParticipationCacheTest.java
@@ -4,11 +4,11 @@ import io.github.jaehyeonhan.project.entity.Participation;
 import io.github.jaehyeonhan.project.entity.ParticipationCache;
 import io.github.jaehyeonhan.project.entity.ParticipationRole;
 import io.github.jaehyeonhan.project.repository.ParticipationRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -38,11 +38,12 @@ class ParticipationCacheTest {
     @Mock
     private ValueOperations<String, ParticipationCache> valueOperations;
 
-    @InjectMocks
     private ParticipationCacheService participationCacheService;
 
     @BeforeEach
     void setUp() {
+        participationCacheService = new ParticipationCacheService(
+            participationRepository, participationRedisTemplate, new SimpleMeterRegistry());
         given(participationRedisTemplate.opsForValue()).willReturn(valueOperations);
     }
 

--- a/app/src/test/java/io/github/jaehyeonhan/project/service/ParticipationCacheTest.java
+++ b/app/src/test/java/io/github/jaehyeonhan/project/service/ParticipationCacheTest.java
@@ -1,0 +1,125 @@
+package io.github.jaehyeonhan.project.service;
+
+import io.github.jaehyeonhan.project.entity.Participation;
+import io.github.jaehyeonhan.project.entity.ParticipationCache;
+import io.github.jaehyeonhan.project.entity.ParticipationRole;
+import io.github.jaehyeonhan.project.repository.ParticipationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static io.github.jaehyeonhan.project.service.ChatTestConst.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class ParticipationCacheTest {
+
+    @Mock
+    private ParticipationRepository participationRepository;
+
+    @Mock
+    private RedisTemplate<String, ParticipationCache> participationRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, ParticipationCache> valueOperations;
+
+    @InjectMocks
+    private ParticipationCacheService participationCacheService;
+
+    @BeforeEach
+    void setUp() {
+        given(participationRedisTemplate.opsForValue()).willReturn(valueOperations);
+    }
+
+    @Test
+    @DisplayName("캐시 미스 시 DB 조회 후 Redis에 저장한다.")
+    void given_cacheMiss_when_get_then_queryDbAndCacheResult() {
+
+        // given
+        String key = "app:participation:" + USER_ID + ":" + CHAT_ID;
+
+        Participation participation = Participation.joinAsUser(PARTICIPATION_ID, USER_ID, CHAT_ID);
+
+        given(valueOperations.get(key)).willReturn(null);
+
+        given(participationRepository.findByUserIdAndChatId(USER_ID, CHAT_ID)).willReturn(
+            Optional.of(participation));
+
+        // when
+        ParticipationCache result = participationCacheService.get(USER_ID, CHAT_ID);
+
+        // then
+        then(participationRepository).should(times(1)).findByUserIdAndChatId(USER_ID, CHAT_ID);
+
+        then(valueOperations).should(times(1))
+            .set(eq(key), any(ParticipationCache.class), eq(Duration.ofMinutes(5)));
+
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(PARTICIPATION_ID);
+        assertThat(result.role()).isEqualTo(ParticipationRole.USER);
+    }
+
+    @Test
+    @DisplayName("캐시 히트 시 DB를 조회하지 않는다.")
+    void given_cacheHit_when_get_then_returnCachedValueWithoutDbQuery() {
+
+        // given
+        String key = "app:participation:" + USER_ID + ":" + CHAT_ID;
+
+        ParticipationCache cached = new ParticipationCache(
+            PARTICIPATION_ID,
+            ParticipationRole.USER,
+            LocalDateTime.now()
+        );
+
+        given(valueOperations.get(key)).willReturn(cached);
+
+        // when
+        ParticipationCache result = participationCacheService.get(USER_ID, CHAT_ID);
+
+        // then
+        then(participationRepository).shouldHaveNoInteractions();
+
+        then(valueOperations).should(never()).set(anyString(), any(), any(Duration.class));
+
+        assertThat(result).isEqualTo(cached);
+    }
+
+    @Test
+    @DisplayName("DB 조회 결과가 없으면 Redis에 저장하지 않는다.")
+    void given_dbReturnsNull_when_get_then_doNotCacheNullValue() {
+
+        // given
+        String key = "app:participation:" + USER_ID + ":" + CHAT_ID;
+
+        given(valueOperations.get(key)).willReturn(null);
+
+        given(participationRepository.findByUserIdAndChatId(USER_ID, CHAT_ID)).willReturn(
+            Optional.empty());
+
+        // when
+        ParticipationCache result = participationCacheService.get(USER_ID, CHAT_ID);
+
+        // then
+        then(participationRepository).should(times(1)).findByUserIdAndChatId(USER_ID, CHAT_ID);
+
+        then(valueOperations).should(never()).set(anyString(), any(), any(Duration.class));
+
+        assertThat(result).isNull();
+    }
+}

--- a/app/src/test/java/io/github/jaehyeonhan/project/service/SendMessageBulkheadIntegrationTest.java
+++ b/app/src/test/java/io/github/jaehyeonhan/project/service/SendMessageBulkheadIntegrationTest.java
@@ -1,0 +1,93 @@
+package io.github.jaehyeonhan.project.service;
+
+import static io.github.jaehyeonhan.project.service.ChatTestConst.CHAT_ID;
+import static io.github.jaehyeonhan.project.service.ChatTestConst.MESSAGE_ID;
+import static io.github.jaehyeonhan.project.service.ChatTestConst.PARTICIPATION_ID;
+import static io.github.jaehyeonhan.project.service.ChatTestConst.USER_ID;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import io.github.jaehyeonhan.project.entity.Participation;
+import io.github.jaehyeonhan.project.entity.ParticipationCache;
+import io.github.jaehyeonhan.project.repository.MessageRepository;
+import io.github.jaehyeonhan.project.repository.ParticipationRepository;
+import io.github.resilience4j.bulkhead.BulkheadFullException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class SendMessageBulkheadIntegrationTest {
+
+    @Autowired
+    ChatService chatService;
+
+    @MockitoBean
+    ChatValidationService chatValidationService;
+
+    @MockitoBean
+    MessageRepository messageRepository;
+
+    @MockitoBean
+    IdGenerator idGenerator;
+
+    @MockitoBean
+    ParticipationRepository participationRepository;
+
+    @MockitoBean
+    RedisTemplate<String, ParticipationCache> participationRedisTemplate;
+
+    @Test
+    @DisplayName("sendMessage() Bulkhead 동시 호출 제한을 초과하면 BulkheadFullException이 발생한다.")
+    void given_bulkheadLimitExceeded_when_sendMessage_then_throwBulkheadFullException()
+        throws Exception {
+
+        Participation participation = Participation.joinAsUser(PARTICIPATION_ID, USER_ID, CHAT_ID);
+
+        CountDownLatch requestsStarted = new CountDownLatch(2);
+        CountDownLatch releaseRequests = new CountDownLatch(1);
+
+        given(chatValidationService.requireParticipation(USER_ID, CHAT_ID))
+            .willAnswer(invocation -> {
+                requestsStarted.countDown();
+                releaseRequests.await(3, TimeUnit.SECONDS);
+                return participation;
+            });
+
+        given(idGenerator.generate()).willReturn(MESSAGE_ID);
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(4)) {
+
+            // 2개의 요청이 Bulkhead semaphore를 점유 (max-concurrent-calls: 2)
+            Future<?> first = executor.submit(() ->
+                chatService.sendMessage(USER_ID, CHAT_ID, "msg"));
+            Future<?> second = executor.submit(() ->
+                chatService.sendMessage(USER_ID, CHAT_ID, "msg"));
+
+            // 두 요청이 모두 Bulkhead 내부에서 블로킹될 때까지 대기
+            requestsStarted.await();
+
+            // 3번째 요청은 max-concurrent-calls: 2 초과 → 즉시 거부
+            Future<?> third = executor.submit(() ->
+                chatService.sendMessage(USER_ID, CHAT_ID, "msg"));
+
+            assertThatThrownBy(third::get)
+                .hasCauseInstanceOf(BulkheadFullException.class);
+
+            releaseRequests.countDown();
+
+            first.get();
+            second.get();
+
+            executor.shutdownNow();
+        }
+    }
+}

--- a/app/src/test/resources/application.yml
+++ b/app/src/test/resources/application.yml
@@ -10,3 +10,41 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      participationCache:
+        sliding-window-size: 2
+        minimum-number-of-calls: 2
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 2s
+        permitted-number-of-calls-in-half-open-state: 1
+        record-exceptions:
+          - org.springframework.data.redis.RedisConnectionFailureException
+          - org.springframework.data.redis.RedisSystemException
+        ignore-exceptions:
+          - io.github.resilience4j.bulkhead.BulkheadFullException
+    circuit-breaker-aspect-order: 1
+
+  retry:
+    instances:
+      participationCache:
+        max-attempts: 3
+        wait-duration: 10ms
+        retry-exceptions:
+          - org.springframework.data.redis.RedisConnectionFailureException
+          - org.springframework.data.redis.RedisSystemException
+    retry-aspect-order: 2
+
+  bulkhead:
+    instances:
+      sendMessage:
+        max-concurrent-calls: 2
+        max-wait-duration: 0ms
+
+logging:
+  level:
+    io.github.resilience4j.retry: DEBUG
+    io.github.resilience4j.circuitbreaker: DEBUG
+    io.github.resilience4j.bulkhead: DEBUG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,18 +6,20 @@ services:
     ports:
       - "8080:8080"
     env_file:
-      - app/.env
+      - .env
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     networks:
       - appnet
       - proxynet
+      - redisnet
 
   postgres:
     image: postgres:18.0
     container_name: postgres
     env_file:
-      - app/.env
+      - .env
     environment:
       POSTGRES_DB: ${DB_NAME}
       POSTGRES_USER: ${DB_USER}
@@ -30,7 +32,7 @@ services:
     networks:
       - appnet
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -43,4 +45,6 @@ networks:
   appnet:
     driver: bridge
   proxynet:
+    external: true
+  redisnet:
     external: true

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -72,6 +72,6 @@ services:
       
 networks:
   redisnet:
-    driver: bridge
+    external: true
   proxynet:
     external: true


### PR DESCRIPTION
## 변경 사항

### 참여 정보 캐싱
- 참여 정보 조회에 Cache-Aside 전략의 Redis 캐싱 적용
- 차단 정보 조회는 즉시 적용을 위해 DB 조회 유지
- 캐시 히트 시 DB 접근 3회 → 2회 감소: 메시지 전송 특성 상 같은 사용자가 짧은 시간 내에 메시지를 여러 번 전송할 가능성이 높아 적지 않은 히트율 예상
- 중앙 캐시인 Redis를 사용하여 분산 환경에서 동일하게 동작

### Redis Resilience 적용
- 전체 메시지 전송 메소드 Bulkhead 적용: DB 커넥션 풀 격리, 초과 시 429 응답 (REST 의미에는 503이 더 적합할 수도 있음)
- 캐시 계층에 일시적 지연 시간 증가 흡수를 위한 Retry 적용
- 캐시 계층에 Redis 장애 격리를 위한 Circuit Breaker 적용
- `/actuator` 경로 Resilience4j (Circuit Breaker, Retry, Bulkhead) 메트릭 노출

### SonarQube 지적 사항 개선
- 상수 클래스의 private 생성자 적용
- 테스트 코드에서 무의미한 `eq()` 제거
- import 정리
- 테스트 클래스 불필요한 `public` 제거
- 오타 수정

### Draft PR 생성 시 테스트 실행되도록 개선

### Swagger 조회 API 시간 예시 수정

## 고려사항
- 현재 `Participation`은 불변 데이터로 동작하여 캐시 일관성 문제 없으나, 강퇴 기능과 같이 참가 자체의 규제가 생기는 경우 캐싱 재검토 필요
- Redis fail-over 시 일부 캐시 사라질 가능성 존재
- Retry와 Circuit Breaker의 세부 설정은 실제 트래픽을 보고 결정해야 하나 현재는 트래픽이 없어 임의로 설정: 전체 latency 한계를 600ms 정도에서 잡고 타임아웃 150ms, Retry 3회까지만 허용

---

closes #9
closes #13
closes #16