### PR TITLE
레이트 리미팅 개선 구조 적용

### DIFF
--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -5,23 +5,38 @@ events {
 }
 
 http {
-    # docker DNS 사용
-    resolver 127.0.0.11 valid=30s;
+    # 도커 DNS
+    resolver 127.0.0.11 valid=5s ipv6=off;
+    resolver_timeout 50ms;
    
     include       mime.types;
     default_type  application/octet-stream;
     
     lua_shared_dict my_limit_req_store 50m;
+    lua_shared_dict sentinel_blacklist 1m;
     
-    # app은 도커 컴포즈 서비스 이름에 맞게 수정 필요
+    # fallback 용 rate limit 메모리 설정
+    init_worker_by_lua_block {
+        local limit_req = require "resty.limit.req"
+
+        -- fallback은 leaky bucket으로 burst 허용 x
+        local lim, err = limit_req.new("my_limit_req_store", 1, 0)
+        if not lim then
+            ngx.log(ngx.ERR, "failed to create limiter: ", err)
+            return
+        end
+
+        package.loaded.my_limiter = lim
+    }
+    
     upstream backend {
-        server app:8080;
+        server app1:8080;
+        server app2:8080;
     }
     
     server {
         listen 80;
        
-        # Common Proxy Settings
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -30,110 +45,90 @@ http {
         location ~ /api/chats/[^/]+/messages {
             access_by_lua_block {
                 if ngx.var.request_method == "POST" then
-                    -- user_id 추출, 프록시에서 헤더 직접 사용은 보안 상 취약할 가능성
                     local headers = ngx.req.get_headers()
                     local user_id = headers["user-id"]
                     if not user_id then
-                        ngx.say("missing user-id header")
                         return ngx.exit(401)
                     end
-                    
-                    -- fallback rate limiting
-                    local limit_req = require "resty.limit.req"
-                    local lim, err = limit_req.new("my_limit_req_store", 0.5, 3)
-                    if not lim then
-                        ngx.log(ngx.ERR,
-                                "failed to instantiate a resty.limit.req object: ", err)
-                        return ngx.exit(500)
-                    end
-                    
+
                     local function fallback()
-                        local key = user_id
-                        local delay, err = lim:incoming(key, true)
+                        ngx.log(ngx.ERR, "using fallback rate limiting")
+                        local lim = package.loaded.my_limiter
+                        local delay, err = lim:incoming(user_id, true)
                         if not delay then
-                            if err == "rejected" then
-                                return ngx.exit(503)
-                            end
-                            ngx.log(ngx.ERR, "failed to limit req: ", err)
+                            if err == "rejected" then return ngx.exit(429) end
                             return ngx.exit(500)
                         end
                         
-                        if delay >= 0.001 then
-                            ngx.log(ngx.ERR, "delay is not allowed with default rate limiting")
-                            return ngx.exit(429)
-                        end
                     end
-                    
+
                     local redis = require "resty.redis"
-                    
-                    -- 현재 Sentinel은 Redis와 동일 컨테이너
+                    local blacklist = ngx.shared.sentinel_blacklist
+
                     local sentinels = {
-                        { host = "redis-master", port = 26379 },
-                        { host = "redis-replica1", port = 26379 },
-                        { host = "redis-replica2", port = 26379 },
+                        {host = "redis-replica1", port = 26379},
+                        {host = "redis-master", port = 26379},
+                        {host = "redis-replica2", port = 26379}
                     }
-                    local master_name = "mymaster"  -- sentinel.conf에서 정의한 master 이름
-                    
-                    -- Sentinel에서 마스터 주소 가져오기
+                    local master_name = "mymaster"
+
+                    -- [Sentinel에서 마스터 주소 가져오기 - 서킷 브레이커 적용]
                     local function get_master()
                         for _, s in ipairs(sentinels) do
-                            local red = redis:new()
-                            red:set_timeout(1000)  -- 1초 타임아웃
-                            local ok, err = red:connect(s.host, s.port)
-                            if not ok then
-                                ngx.log(ngx.ERR, "failed to connect to sentinel ", s.host, ":", s.port, " - ", err)
-                            else
-                                local res, err = red:sentinel("get-master-addr-by-name", master_name)
-                                if res and #res == 2 then
-                                    -- res[1] = IP, res[2] = port
-                                    return res[1], tonumber(res[2])
+                            if not blacklist:get(s.host) then
+                                local red = redis:new()
+                                red:set_timeout(100) -- 연결 타임아웃 0.1초
+                                
+                                local ok, err = red:connect(s.host, s.port)
+                                if ok then
+                                    local res, err = red:sentinel("get-master-addr-by-name", master_name)
+                                    if res and #res == 2 then
+                                        return res[1], tonumber(res[2])
+                                    end
+                                else
+                                    -- 연결 실패 시 10초간 블랙리스트 등록 (DNS Lookup 시도 차단)
+                                    blacklist:set(s.host, true, 10)
+                                    ngx.log(ngx.ERR, "Sentinel ", s.host, " connection failed. Blacklisting for 10s: ", err)
                                 end
                             end
                         end
                         return nil, nil
                     end
 
-                    -- 마스터 조회 및 연결
-                    local function connect_master(retries)
-                        retries = retries or 3
-                        local last_err
-                        for i = 1, retries do
-                            local master_ip, master_port = get_master()  -- Sentinel 조회
-                            if master_ip then
-                                local red = redis:new()
-                                red:set_timeout(1000)
-                                local ok, err = red:connect(master_ip, master_port)
-                                if ok then
-                                    return red
-                                else
-                                    last_err = err
-                                    ngx.log(ngx.WARN, "failed to connect master, retrying: ", err)
-                                    ngx.sleep(0.1)
-                                end
-                            else
-                                last_err = "cannot get master from sentinels"
-                                ngx.sleep(0.1)
-                            end
+                    -- 마스터 연결
+                    local function connect_master()
+                        local master_ip, master_port = get_master()
+                        if master_ip then
+                            local red = redis:new()
+                            red:set_timeout(100)
+                            local ok, err = red:connect(master_ip, master_port)
+                            if ok then return red else return nil, err end
+                        else
+                            return nil, "all sentinels failed or blacklisted"
                         end
-                        return nil, last_err
                     end
-                    
+
                     local red, err = connect_master()
                     if not red then
-                        ngx.log(ngx.ERR, err)
+                        ngx.log(ngx.ERR, "Redis Master Connection Error: ", err)
                         fallback()
                         return
                     end
 
-                    -- 등록한 Redis Function 호출
+                    -- Redis Function 실행
                     local res, err = red:fcall("check_if_allowed", 0, user_id)
+                    
+                    red:set_keepalive(10000, 100)
+
                     if not res then
                         ngx.log(ngx.ERR, "failed to call redis function: ", err)
-                        return ngx.exit(500)
+                        fallback();
+                        return
                     end
-                    
-                    -- 결과에 따른 반환
-                    if res == 0 then return ngx.exit(429) end
+
+                    if res == 0 then
+                        return ngx.exit(429)
+                    end
                 end
             }
             

--- a/infra/redis/master-init.sh/master-init.sh
+++ b/infra/redis/master-init.sh/master-init.sh
@@ -1,0 +1,3 @@
+cat /etc/redis/lua/token_bucket.lua | redis-cli -x FUNCTION LOAD
+redis-cli SET rate_limit:config:bucket_size 4
+redis-cli SET rate_limit:config:refill_rate 1

--- a/infra/redis/token_bucket.lua
+++ b/infra/redis/token_bucket.lua
@@ -4,17 +4,17 @@ local function check_if_allowed(keys, args)
     local bucket_size = tonumber(redis.call("GET", "rate_limit:config:bucket_size"))
     local refill_rate = tonumber(redis.call("GET", "rate_limit:config:refill_rate"))
 
-    local user_id = args[1] -- cluster 적용 시 keys로 변경해야 함
+    local user_id = args[1]
     local t = redis.call("TIME")
     local now_sec = tonumber(t[1])
 
     -- 현재 토큰 개수 조회 및 token 변수 갱신
-    local tokens_key = "rate_limit:user:" .. user_id .. ":tokens" -- cluster 적용 시 hashtag 적용 필요
+    local tokens_key = "rate_limit:user:" .. user_id .. ":tokens"
     local tokens = tonumber(redis.call("GET", tokens_key))
     if tokens == nil then tokens = bucket_size end
 
     -- 마지막 충전 시각 조회
-    local ts_key = "rate_limit:user:" .. user_id .. ":last_refill" -- cluster 적용 시 hashtag 적용 필요
+    local ts_key = "rate_limit:user:" .. user_id .. ":last_refill"
     local last = tonumber(redis.call("GET", ts_key))
     if not last then 
         last = now_sec 


### PR DESCRIPTION
## 변경 사항

### rate-limit-test 브랜치에서의 개선 내용 적용
- 레디스 마스터 초기화 스크립트 추가: `bucket_size`=4, `refill_rate`=1
- fallback rate limit 에서 burst 제거 및 간이 circuit breaker 적용
- 레디스 연결 타임아웃 시간 하향 조정
- 레디스 keep-alive 적용